### PR TITLE
UTF-8 text sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Indicates whether the specified CString is null or an empty UTF-8 text.
 Retrieves the internal binary data from a given <see cref="CString"/>.
 
 ## CStringSequence
-Represents a sequence of UTF-8 texts.
+Represents a sequence of null-terminated UTF-8 texts.
 * AsSpan
 Retrieves the buffer as an ReadOnlySpan<Char> instance and creates a CString array which represents 
 text sequence. The output CString array will remain valid only as long as returned buffer span is on live.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Indicates whether the specified CString is null or an empty UTF-8 text.
 * GetBytes(CString value)
 Retrieves the internal binary data from a given <see cref="CString"/>.
 
+## CStringSequence
+Represents a sequence of UTF-8 texts.
+* AsSpan
+Retrieves the buffer as an ReadOnlySpan<Char> instance and creates a CString array which represents 
+text sequence. The output CString array will remain valid only as long as returned buffer span is on live.
+
 ## InputValue
 Supports a value type that can be referenced.
 * CreateInput&lt;TValue&gt;(in TValue instance)

--- a/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/AsSpanTest.cs
+++ b/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/AsSpanTest.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using AutoFixture;
+
+using Xunit;
+
+namespace Rxmxnx.PInvoke.Extensions.Tests.CStringSequenceTest
+{
+    [ExcludeFromCodeCoverage]
+    public sealed class AsSpanTest
+    {
+        [Fact]
+        internal void NormalTest()
+        {
+            CString[] localValues = TestUtilities.SharedFixture.Create<String[]>().Select(x => (CString)x).ToArray();
+            String[] strValue = TestUtilities.SharedFixture.Create<String[]>();
+            Byte[][] bytes = strValue.Select(x => Encoding.UTF8.GetBytes(x)).ToArray();
+            GCHandle[] handles = TestUtilities.Alloc(bytes);
+            try
+            {
+                ExecuteTest(localValues, TestUtilities.CreateCStrings(bytes, handles));
+            }
+            finally
+            {
+                TestUtilities.Free(handles);
+            }
+        }
+
+        private static void ExecuteTest(CString[] localValues, CString[] externalValues)
+        {
+            CString[] allValues = MixValues(localValues, externalValues);
+            Int32 expectedTextLength = GetExpectedTextLength(allValues);
+            Int32 expectedStringLength = GetExpectedStringLength(expectedTextLength);
+            String[] expectedValue = allValues.Select(x => x?.ToString()).ToArray();
+
+            CStringSequence sequence = new(allValues);
+            ReadOnlySpan<Char> buffer = sequence.AsSpan(out CString[] output);
+
+            Assert.Equal(expectedStringLength, buffer.Length);
+            Assert.Equal(allValues.Length, output.Length);
+            for (Int32 i = 0; i < allValues.Length; i++)
+            {
+                Boolean isNullOrEmpty = CString.IsNullOrEmpty(allValues[i]);
+
+                Assert.Equal(isNullOrEmpty, CString.IsNullOrEmpty(output[i]));
+                Assert.NotNull(output[i]);
+                Assert.True(output[i].IsNullTerminated);
+                if (!isNullOrEmpty)
+                {
+                    Assert.True(output[i].IsReference);
+                    Assert.Equal(expectedValue[i], output[i].ToString());
+                }
+                else
+                    Assert.False(output[i].IsReference);
+            }
+        }
+
+        private static CString[] MixValues(CString[] localValues, CString[] externalValues)
+            => localValues.Concat(externalValues)
+            .Concat(Enumerable.Repeat<CString>(default, sizeof(Char)))
+            .Concat(Enumerable.Repeat<CString>("", sizeof(Char)))
+            .OrderBy(x => Guid.NewGuid())
+            .ToArray();
+
+        private static Int32 GetExpectedTextLength(CString[] allValues)
+            => allValues.Where(x => !CString.IsNullOrEmpty(x)).Select(x => x.Length + 1).Sum() - 1;
+
+        private static Int32 GetExpectedStringLength(int expectedTextLength)
+            => expectedTextLength / sizeof(Char) + expectedTextLength % sizeof(Char);
+    }
+}

--- a/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/AsSpanTest.cs
+++ b/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/AsSpanTest.cs
@@ -42,6 +42,12 @@ namespace Rxmxnx.PInvoke.Extensions.Tests.CStringSequenceTest
 
             Assert.Equal(expectedStringLength, buffer.Length);
             Assert.Equal(allValues.Length, output.Length);
+            TextTest(allValues, expectedValue, output);
+            ConcatTest(sequence);
+        }
+
+        private static void TextTest(CString[] allValues, String[] expectedValue, CString[] output)
+        {
             for (Int32 i = 0; i < allValues.Length; i++)
             {
                 Boolean isNullOrEmpty = CString.IsNullOrEmpty(allValues[i]);
@@ -59,6 +65,37 @@ namespace Rxmxnx.PInvoke.Extensions.Tests.CStringSequenceTest
             }
         }
 
+        private static void ConcatTest(CStringSequence sequence)
+        {
+            ReadOnlySpan<Char> buffer = sequence.AsSpan(out CString[] output);
+            Int32[] lengths = output.Select(x => x.Length).ToArray();
+            CString join = output.Concat();
+            ReadOnlySpan<Byte> span = join;
+            CString[] output2 = GetCString(span, lengths);
+            CStringSequence sequence2 = new(output2);
+            ReadOnlySpan<Char> buffer2 = sequence2.AsSpan(out CString[] output3);
+
+            Assert.Equal(sequence, sequence2);
+            for (Int32 i = 0; i < lengths.Length; i++)
+            {
+                Assert.Equal(output[i], output2[i]);
+                Assert.Equal(output[i], output3[i]);
+            }
+        }
+
+        private static CString[] GetCString(ReadOnlySpan<Byte> span, Int32[] lengths)
+        {
+            IntPtr ptr = span.AsIntPtr();
+            CString[] result = new CString[lengths.Length];
+            Int32 offset = 0;
+            for (Int32 i = 0; i < lengths.Length; i++)
+            {
+                result[i] = new(ptr + offset, lengths[i]);
+                offset += lengths[i];
+            }
+            return result;
+        }
+
         private static CString[] MixValues(CString[] localValues, CString[] externalValues)
             => localValues.Concat(externalValues)
             .Concat(Enumerable.Repeat<CString>(default, sizeof(Char)))
@@ -69,7 +106,7 @@ namespace Rxmxnx.PInvoke.Extensions.Tests.CStringSequenceTest
         private static Int32 GetExpectedTextLength(CString[] allValues)
             => allValues.Where(x => !CString.IsNullOrEmpty(x)).Select(x => x.Length + 1).Sum() - 1;
 
-        private static Int32 GetExpectedStringLength(int expectedTextLength)
+        private static Int32 GetExpectedStringLength(Int32 expectedTextLength)
             => expectedTextLength / sizeof(Char) + expectedTextLength % sizeof(Char);
     }
 }

--- a/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/CloneTest.cs
+++ b/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/CloneTest.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+using AutoFixture;
+
+using Xunit;
+
+namespace Rxmxnx.PInvoke.Extensions.Tests.CStringSequenceTest
+{
+    [ExcludeFromCodeCoverage]
+    public sealed class CloneTest
+    {
+        [Fact]
+        internal void NormalTest()
+        {
+            String value = TestUtilities.SharedFixture.Create<String>();
+            CStringSequence sequence1 = new(TestUtilities.SharedFixture.Create<String>(), TestUtilities.SharedFixture.Create<String>());
+            CStringSequence sequence2 = (CStringSequence)sequence1.Clone();
+            ReadOnlySpan<Char> span1 = sequence1.AsSpan(out CString[] output1);
+            ReadOnlySpan<Char> span2 = sequence2.AsSpan(out CString[] output2);
+
+            Assert.Equal(sequence1, sequence2);
+            Assert.False(Unsafe.AreSame(ref Unsafe.AsRef(span1[0]), ref Unsafe.AsRef(span2[0])));
+        }
+    }
+}

--- a/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/EqualityTest.cs
+++ b/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/EqualityTest.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+using AutoFixture;
+
+using Xunit;
+
+namespace Rxmxnx.PInvoke.Extensions.Tests.CStringSequenceTest
+{
+    [ExcludeFromCodeCoverage]
+    public sealed class EqualityTest
+    {
+        [Fact]
+        internal void NormalTest()
+        {
+            String value = TestUtilities.SharedFixture.Create<String>();
+            CStringSequence sequence1 = new(value);
+            CStringSequence sequence2 = new(value, default);
+            CStringSequence sequence3 = new(default, value);
+            CStringSequence sequence4 = new(value);
+
+            Assert.Equal(sequence1.ToString(), sequence2.ToString());
+            Assert.Equal(sequence1.GetHashCode(), sequence2.GetHashCode());
+            Assert.False(sequence1.Equals(sequence2));
+            Assert.False(sequence1.Equals((Object)sequence2));
+
+            Assert.Equal(sequence1.ToString(), sequence3.ToString());
+            Assert.Equal(sequence1.GetHashCode(), sequence3.GetHashCode());
+            Assert.False(sequence1.Equals(sequence3));
+            Assert.False(sequence1.Equals((Object)sequence3));
+
+            Assert.Equal(sequence1.ToString(), sequence4.ToString());
+            Assert.Equal(sequence1.GetHashCode(), sequence4.GetHashCode());
+            Assert.True(sequence1.Equals(sequence4));
+            Assert.True(sequence1.Equals((Object)sequence4));
+        }
+    }
+}

--- a/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/EqualityTest.cs
+++ b/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/EqualityTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 using AutoFixture;
 
@@ -33,6 +34,10 @@ namespace Rxmxnx.PInvoke.Extensions.Tests.CStringSequenceTest
             Assert.Equal(sequence1.GetHashCode(), sequence4.GetHashCode());
             Assert.True(sequence1.Equals(sequence4));
             Assert.True(sequence1.Equals((Object)sequence4));
+
+            ReadOnlySpan<Char> span = sequence1.AsSpan(out CString[] output);
+            Assert.False(sequence1.Equals(default));
+            Assert.False(sequence1.Equals(output.FirstOrDefault()));
         }
     }
 }

--- a/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/ToStringTest.cs
+++ b/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/ToStringTest.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+using AutoFixture;
+
+using Xunit;
+
+namespace Rxmxnx.PInvoke.Extensions.Tests.CStringSequenceTest
+{
+    [ExcludeFromCodeCoverage]
+    public sealed class ToStringTest
+    {
+        [Fact]
+        internal void NormalTest()
+        {
+            CStringSequence sequence = new(
+                TestUtilities.SharedFixture.Create<String>(), TestUtilities.SharedFixture.Create<String>(),
+                TestUtilities.SharedFixture.Create<String>(), TestUtilities.SharedFixture.Create<String>());
+
+            ReadOnlySpan<Char> span = sequence.AsSpan(out CString[] cstrs);
+            String toString = sequence.ToString();
+            String strBuild = GetExpectedString(cstrs);
+            Int32 expectedLength = span.Length * sizeof(Char);
+            CString spanAsCString = new CString(span.AsIntPtr(), expectedLength);
+
+            Assert.True(Unsafe.AreSame(ref Unsafe.AsRef(span[0]), ref Unsafe.AsRef(toString.AsSpan()[0])));
+            Assert.NotEqual(strBuild, toString);
+            Assert.Equal(strBuild, spanAsCString.ToString());
+        }
+
+        private static String GetExpectedString(CString[] cstrs)
+        {
+            StringBuilder strBuild = new();
+            foreach (CString cstr in cstrs)
+            {
+                strBuild.Append(cstr);
+                strBuild.Append(default(Char));
+            }
+            strBuild.Remove(strBuild.Length - 1, 1);
+            return strBuild.ToString();
+        }
+    }
+}

--- a/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/ToStringTest.cs
+++ b/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/ToStringTest.cs
@@ -21,13 +21,16 @@ namespace Rxmxnx.PInvoke.Extensions.Tests.CStringSequenceTest
 
             ReadOnlySpan<Char> span = sequence.AsSpan(out CString[] cstrs);
             String toString = sequence.ToString();
-            String strBuild = GetExpectedString(cstrs);
+            String expectedString = GetExpectedString(cstrs);
             Int32 expectedLength = span.Length * sizeof(Char);
             CString spanAsCString = new CString(span.AsIntPtr(), expectedLength);
+            CString joinCString = TextUtilities.Join(default(Byte), cstrs);
 
             Assert.True(Unsafe.AreSame(ref Unsafe.AsRef(span[0]), ref Unsafe.AsRef(toString.AsSpan()[0])));
-            Assert.NotEqual(strBuild, toString);
-            Assert.Equal(strBuild, spanAsCString.ToString());
+            Assert.NotEqual(expectedString, toString);
+            Assert.True(toString.Length < expectedLength);
+            Assert.Equal(expectedString, spanAsCString.ToString());
+            Assert.Equal(expectedString, joinCString.ToString());
         }
 
         private static String GetExpectedString(CString[] cstrs)

--- a/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/ToStringTest.cs
+++ b/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/ToStringTest.cs
@@ -23,7 +23,7 @@ namespace Rxmxnx.PInvoke.Extensions.Tests.CStringSequenceTest
             String toString = sequence.ToString();
             String expectedString = GetExpectedString(cstrs);
             Int32 expectedLength = span.Length * sizeof(Char);
-            CString spanAsCString = new CString(span.AsIntPtr(), expectedLength);
+            CString spanAsCString = new(span.AsIntPtr(), expectedLength);
             CString joinCString = TextUtilities.Join(default(Byte), cstrs);
 
             Assert.True(Unsafe.AreSame(ref Unsafe.AsRef(span[0]), ref Unsafe.AsRef(toString.AsSpan()[0])));

--- a/src/Rxmxnx.PInvoke.Extensions.Tests/Rxmxnx.PInvoke.Extensions.Tests.csproj
+++ b/src/Rxmxnx.PInvoke.Extensions.Tests/Rxmxnx.PInvoke.Extensions.Tests.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Rxmxnx.PInvoke.Extensions/CString.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/CString.cs
@@ -161,7 +161,7 @@ namespace Rxmxnx.PInvoke.Extensions
         /// <summary>
         /// Returns a reference to this instance of <see cref="CString"/>.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A new object that is a copy of this instance.</returns>
         /// <exception cref="NotImplementedException"></exception>
         public Object Clone() => new CString(this._data.ToArray());
 

--- a/src/Rxmxnx.PInvoke.Extensions/CStringSequence.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/CStringSequence.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace Rxmxnx.PInvoke.Extensions
 {
     /// <summary>
-    /// Represents a sequence of UTF-8 texts.
+    /// Represents a sequence of null-terminated UTF-8 texts.
     /// </summary>
     public sealed record CStringSequence
     {

--- a/src/Rxmxnx.PInvoke.Extensions/CStringSequence.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/CStringSequence.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rxmxnx.PInvoke.Extensions
+{
+    /// <summary>
+    /// Represents a sequence of UTF-8 texts.
+    /// </summary>
+    public sealed record CStringSequence
+    {
+        /// <summary>
+        /// Size of <see cref="Char"/> value.
+        /// </summary>
+        private const Int32 sizeOfChar = sizeof(Char);
+
+        /// <summary>
+        /// Internal buffer.
+        /// </summary>
+        private readonly String _value;
+        /// <summary>
+        /// Collection of text length for buffer interpretation.
+        /// </summary>
+        private readonly Int32[] _lengths;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="values">Text collection.</param>
+        public CStringSequence(params CString?[] values)
+        {
+            this._lengths = values.Select(c => c?.Length ?? default).ToArray();
+            this._value = CreateBuffer(this._lengths, values);
+        }
+
+        /// <summary>
+        /// Retrieves the buffer as an <see cref="ReadOnlySpan{Char}"/> instance and creates a
+        /// <see cref="CString"/> array which represents text sequence.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="output"/> will remain valid only as long as returned 
+        /// <see cref="ReadOnlySpan{Char}"/> is on live.
+        /// </remarks>
+        /// <param name="output"><see cref="CString"/> array.</param>
+        /// <returns>Buffer <see cref="ReadOnlySpan{Char}"/>.</returns>
+        public ReadOnlySpan<Char> AsSpan(out CString[] output)
+        {
+            ReadOnlySpan<Char> result = this._value;
+            output = this.GetValues(result.AsIntPtr()).ToArray();
+            return this._value;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="String"/> that represents the current object.
+        /// </summary>
+        /// <returns>A <see cref="String"/> that represents the current object.</returns>
+        public override String ToString() => this._value;
+
+        /// <summary>
+        /// Retrieves the sequence of <see cref="CString"/> based on the buffer and lengths.
+        /// </summary>
+        /// <param name="ptr">Buffer pointer.</param>
+        /// <returns>Collection of <see cref="CString"/>.</returns>
+        private IEnumerable<CString> GetValues(IntPtr ptr)
+        {
+            Int32 offset = 0;
+            for (Int32 i = 0; i < this._lengths.Length; i++)
+            {
+                if (this._lengths[i] > 0)
+                {
+                    yield return new(ptr + offset, this._lengths[i] + 1);
+                    offset += this._lengths[i] + 1;
+                }
+                else
+                    yield return CString.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Creates the sequence buffer.
+        /// </summary>
+        /// <param name="lengths">Text length collection.</param>
+        /// <param name="values">Text collection.</param>
+        /// <returns>
+        /// <see cref="String"/> instance that contains the binary information of the UTF-8 text sequence.
+        /// </returns>
+        private static String CreateBuffer(Int32[] lengths, CString?[] values)
+        {
+            Int32 count = lengths.Sum() + lengths.Length - 1;
+            StringBuilder sb = new(count / sizeOfChar + count % sizeOfChar);
+            Boolean pending = false;
+            Byte previous = default;
+            for (Int32 i = 0; i < lengths.Length; i++)
+                CopyText(sb, values[i], ref pending, ref previous);
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Copy the UTF-8 into the buffer builder.
+        /// </summary>
+        /// <param name="strBuild">Buffer builder.</param>
+        /// <param name="cstr">UTF-8 text.</param>
+        /// <param name="pending">
+        /// <list type="table">
+        /// <item>
+        /// <term>Input</term>
+        /// <description>
+        /// Indicates whether the current method call should write a pending UTF-8 character from the 
+        /// previous method call.
+        /// </description>
+        /// </item>
+        /// <item>
+        /// <term>Output</term>
+        /// <description>Indicates whether the next call should write a leftover UTF-8 character.</description>
+        /// </item>
+        /// </list>
+        /// </param>
+        /// <param name="previous">
+        /// <list type="table">
+        /// <item>
+        /// <term>Input</term>
+        /// <description>Pending UTF-8 character from previous method call.</description>
+        /// </item>
+        /// <item>
+        /// <term>Output</term>
+        /// <description>Pending UTF-8 character to next method call.</description>
+        /// </item>
+        /// </list>
+        /// </param>
+        private static void CopyText(StringBuilder strBuild, CString? cstr, ref Boolean pending, ref Byte previous)
+        {
+            if (!CString.IsNullOrEmpty(cstr))
+            {
+                Int32 offset = 0;
+                ReadOnlySpan<Byte> span = cstr;
+                if (pending)
+                {
+                    Byte[] firstChar = new Byte[sizeOfChar];
+                    firstChar[0] = previous;
+                    firstChar[1] = span[0];
+                    offset = 1;
+                    strBuild.Append(firstChar.AsValue<Char>());
+                }
+#pragma warning disable CS8602
+                Int32 desiredSize = cstr.Length + 1 - offset;
+#pragma warning restore CS8602
+                if (span.Length - offset > 0)
+                {
+                    Int32 charCount = span.Length / sizeOfChar;
+                    ReadOnlySpan<Char> chars = (span.AsIntPtr() + offset).AsReadOnlySpan<Char>(charCount);
+                    foreach (Char c in chars)
+                        strBuild.Append(c);
+
+                    pending = chars.Length != desiredSize / sizeOfChar || desiredSize % sizeOfChar != 0;
+                    previous = pending && cstr.Length < span.Length ? span[^1] : default;
+                }
+            }
+        }
+    }
+}

--- a/src/Rxmxnx.PInvoke.Extensions/CStringSequence.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/CStringSequence.cs
@@ -152,7 +152,7 @@ namespace Rxmxnx.PInvoke.Extensions
                     foreach (Char c in chars)
                         strBuild.Append(c);
 
-                    pending = chars.Length != desiredSize / sizeOfChar || desiredSize % sizeOfChar != 0;
+                    pending = desiredSize % sizeOfChar != 0;
                     previous = pending && cstr.Length < span.Length ? span[^1] : default;
                 }
             }

--- a/src/Rxmxnx.PInvoke.Extensions/Internal/Utf8CStringConcatenation.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/Internal/Utf8CStringConcatenation.cs
@@ -53,7 +53,7 @@ namespace Rxmxnx.PInvoke.Extensions.Internal
         /// <summary>
         /// Writes the concatenation of given text collection into the buffer.
         /// </summary>
-        /// <param name="values">Texts collection.</param>
+        /// <param name="values">Text collection.</param>
         private async Task WriteAsync(IEnumerable<CString> values)
         {
             foreach (CString value in values)

--- a/src/Rxmxnx.PInvoke.Extensions/Internal/Utf8StringConcatenation.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/Internal/Utf8StringConcatenation.cs
@@ -65,7 +65,7 @@ namespace Rxmxnx.PInvoke.Extensions.Internal
         /// <summary>
         /// Writes the concatenation of given text collection into the buffer.
         /// </summary>
-        /// <param name="values">Texts collection.</param>
+        /// <param name="values">Text collection.</param>
         private async Task WriteAsync(IEnumerable<String> values)
         {
             foreach (String value in values)


### PR DESCRIPTION
We may need a simpler way to store a collection of null-terminated UTF-8 texts in memory.
The Join functions can be used for this purpose by explicitly declaring the null UTF-8 character as the separator.
However, the 'Join' concept may not be suitable in all contexts since, like any local CString, the UTF-8 text is stored in a byte array.
In some contexts, especially native ones, it is desirable to simplify the storage of UTF-8 text regardless of the ability to operate on asynchronous contexts.
In this way, an object is proposed that can contain a defined sequence of UTF-8 texts but, unlike any local CString, storing the binary data into a String instance. Additionally, unlike a normal Join, we can create CString instances which point to begin of all UTF-8 text inside the sequence.
# Storage implications
There are differences that have implications when choosing to use Byte[] or String as container for UTF-8 binary information.
## Byte[]:
* Termination flexibility. In many cases null-termination is not required or desirable.
* Inability to be used as a key.
* Ability to easily obtain binary information in both synchronous and asynchronous contexts.
* UTF-8 termination character length matches with UTF-8 null character length.
## String:
* Always use null termination of the text.
* Ability to be used as a key.
* Difficulty accessing individual UTF-8 units in synchronous contexts. They cannot be accessed in asynchronous contexts.
* Length of the termination character is equivalent to that of UTF-16. So there will always be an additional byte compared to its Byte[] equivalent.