### PR TITLE
IWrapper<T> and IReferenceable<T>improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,19 +127,13 @@ text sequence. The output CString array will remain valid only as long as return
 ## InputValue
 Supports a value type that can be referenced.
 * **CreateInput&lt;TValue&gt;(in TValue instance)**
-Gets a IReferenceable&lt;TValue&gt; object from a generic value.
+Creates a new IReferenceableWrapper&lt;TValue&gt; object from a generic value.
 * **CreateInput&lt;TValue?&gt;(in TValue? instance)**
-Gets a IReferenceable&lt;TValue&gt; object from a generic nullable value.
+Creates a new IReferenceableWrapper&lt;TValue&gt; object from a generic nullable value.
 * **CreateReference&lt;TValue&gt;(in TValue instance = default)**
-Gets a IMutableReference&lt;TValue&gt; object from a generic value.
+Creates a new IMutableReference&lt;TValue&gt; object from a generic value.
 * **CreateReference&lt;TValue?&gt;(in TValue? instance = default)**
-Gets a IMutableReference&lt;TValue&gt; object from a generic nullable value.
-### IReferenceable&lt;TValue&gt;
-* **GetInstanceValue&lt;TValue&gt;()**
-Gets the internal instance value.
-### IReferenceable&lt;TValue?&gt;
-* **GetInstanceValue&lt;TValue?&gt;()**
-Gets the internal instance nullable value.
+Creates a new IMutableReference&lt;TValue&gt; object from a generic nullable value.
 
 ## NativeUtilities
 Provides a set of utilities for exchange data within the P/Invoke context.

--- a/src/Rxmxnx.PInvoke.Extensions.Tests/InputValueTest/ReferenceableWrapperTest.cs
+++ b/src/Rxmxnx.PInvoke.Extensions.Tests/InputValueTest/ReferenceableWrapperTest.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace Rxmxnx.PInvoke.Extensions.Tests.InputValueTest
 {
     [ExcludeFromCodeCoverage]
-    public sealed class ReferenceableTest
+    public sealed class ReferenceableWrapperTest
     {
         [Theory]
         [InlineData(null)]
@@ -72,23 +72,25 @@ namespace Rxmxnx.PInvoke.Extensions.Tests.InputValueTest
                 NormalNullableTest(InputValue.CreateInput(initialValue), initialValue);
         }
 
-        private static void NormalValueTest<T>(IReferenceable<T> valueInput, T initialValue)
+        private static void NormalValueTest<T>(IReferenceableWrapper<T> valueInput, T initialValue)
             where T : struct
         {
             GeneralTest(valueInput, ref initialValue);
             Assert.False(valueInput.Equals(InputValue.CreateInput(initialValue)));
             Assert.False(valueInput.Equals(default(IReferenceable<T>)));
+            Assert.False(valueInput.Equals(default(IWrapper<T>)));
         }
 
-        private static void NormalNullableTest<T>(IReferenceable<T?> valueInput, T? initialValue)
+        private static void NormalNullableTest<T>(IReferenceableWrapper<T?> valueInput, T? initialValue)
             where T : struct
         {
             GeneralTest(valueInput, ref initialValue);
             Assert.False(valueInput.Equals(InputValue.CreateInput(initialValue)));
-            Assert.False(valueInput.Equals(default(IReferenceable<T?>)));
+            Assert.False(valueInput.Equals(default(IReferenceable<T>)));
+            Assert.False(valueInput.Equals(default(IWrapper<T>)));
         }
 
-        private static void GeneralTest<T>(IReferenceable<T> valueInput, ref T initialValue)
+        private static void GeneralTest<T>(IReferenceableWrapper<T> valueInput, ref T initialValue)
         {
             Assert.Equal(initialValue, valueInput.Value);
             Assert.True(valueInput.Equals(initialValue));

--- a/src/Rxmxnx.PInvoke.Extensions/IMutableWrapper.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/IMutableWrapper.cs
@@ -1,0 +1,16 @@
+﻿namespace Rxmxnx.PInvoke.Extensions
+{
+    /// <summary>
+    /// This interface exposes a wrapper for <typeparamref name="T"/> object whose value 
+    /// can be modified.
+    /// </summary>
+    /// <typeparam name="T">Type of wrapped value.</typeparam>
+    public interface IMutableWrapper<T> : IWrapper<T>
+    {
+        /// <summary>
+        /// Sets the instance object.
+        /// </summary>
+        /// <param name="newValue">New <typeparamref name="T"/> object to set as instance object.</param>
+        void SetInstance(T? newValue);
+    }
+}

--- a/src/Rxmxnx.PInvoke.Extensions/IReferenceable.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/IReferenceable.cs
@@ -1,16 +1,20 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace Rxmxnx.PInvoke.Extensions
 {
     /// <summary>
-    /// This interface exposes an object which contains a reference to an inmutable <typeparamref name="T"/> object.
+    /// This interface exposes a read-only reference to <typeparamref name="T"/> object.
     /// </summary>
     /// <typeparam name="T">Type of the referenced object.</typeparam>
-    public interface IReferenceable<T> : IWrapper<T>, IEquatable<IReferenceable<T>>
+    public interface IReferenceable<T> : IEquatable<IReferenceable<T>>
     {
         /// <summary>
         /// Reference to instance <typeparamref name="T"/> object.
         /// </summary>
-        ref readonly T Reference { get; }
+        ref readonly T? Reference { get; }
+
+        Boolean IEquatable<IReferenceable<T>>.Equals(IReferenceable<T>? other)
+            => other is not null && Unsafe.AreSame(ref Unsafe.AsRef(this.Reference), ref Unsafe.AsRef(other.Reference));
     }
 }

--- a/src/Rxmxnx.PInvoke.Extensions/IReferenceableWrapper.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/IReferenceableWrapper.cs
@@ -2,10 +2,10 @@
 {
     /// <summary>
     /// This interface exposes a wrapper for <typeparamref name="T"/> object that can be 
-    /// referenced and whose value can be modified.
+    /// referenced.
     /// </summary>
     /// <typeparam name="T">Type of both wrapped and referenced value.</typeparam>
-    public interface IMutableReference<T> : IReferenceableWrapper<T>, IMutableWrapper<T>
+    public interface IReferenceableWrapper<T> : IWrapper<T>, IReferenceable<T>
     {
     }
 }

--- a/src/Rxmxnx.PInvoke.Extensions/IWrapper.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/IWrapper.cs
@@ -3,7 +3,7 @@
 namespace Rxmxnx.PInvoke.Extensions
 {
     /// <summary>
-    /// This interface exposes an object which represents a wrapper of <typeparamref name="T"/> object.
+    /// This interface exposes a wrapper for <typeparamref name="T"/> object.
     /// </summary>
     /// <typeparam name="T">Type of wrapped value.</typeparam>
     public interface IWrapper<T> : IEquatable<T>
@@ -11,6 +11,8 @@ namespace Rxmxnx.PInvoke.Extensions
         /// <summary>
         /// Wrapped <typeparamref name="T"/> object.
         /// </summary>
-        public T Value { get; }
+        public T? Value { get; }
+
+        Boolean IEquatable<T>.Equals(T? other) => Object.Equals(this.Value, other);
     }
 }

--- a/src/Rxmxnx.PInvoke.Extensions/InputValue.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/InputValue.cs
@@ -11,28 +11,29 @@ namespace Rxmxnx.PInvoke.Extensions
     public static class InputValue
     {
         /// <summary>
-        /// Creates a new <see cref="IReferenceable{TValue}"/> object from a <typeparamref name="TValue"/> value.
+        /// Creates a new <see cref="IReferenceableWrapper{TValue}"/> object from a 
+        /// <typeparamref name="TValue"/> value.
         /// </summary>
         /// <typeparam name="TValue"><see cref="ValueType"/> of object.</typeparam>
         /// <param name="instance">Instance value.</param>
         /// <returns>
-        /// <see cref="IReferenceable{TValue}"/> object which instance object is equal to 
+        /// <see cref="IReferenceableWrapper{TValue}"/> object which instance object is equal to 
         /// <paramref name="instance"/>.
         /// </returns>
-        public static IReferenceable<TValue> CreateInput<TValue>(in TValue instance) where TValue : struct
+        public static IReferenceableWrapper<TValue> CreateInput<TValue>(in TValue instance) where TValue : struct
             => new ValueInput<TValue>(instance);
 
         /// <summary>
-        /// Creates a new <see cref="IReferenceable{TValue}"/> object from a 
+        /// Creates a new <see cref="IReferenceableWrapper{TValue}"/> object from a 
         /// <see cref="Nullable{TValue}"/> value.
         /// </summary>
         /// <typeparam name="TValue"><see cref="ValueType"/> of nullable object.</typeparam>
         /// <param name="instance">Instance nullable value.</param>
         /// <returns>
-        /// <see cref="IReferenceable{TValue}"/> object which instance object is equal to 
+        /// <see cref="IReferenceableWrapper{TValue}"/> object which instance object is equal to 
         /// <paramref name="instance"/>.
         /// </returns>
-        public static IReferenceable<TValue?> CreateInput<TValue>(in TValue? instance) where TValue : struct
+        public static IReferenceableWrapper<TValue?> CreateInput<TValue>(in TValue? instance) where TValue : struct
             => new NullableInput<TValue>(instance);
 
         /// <summary>
@@ -61,47 +62,18 @@ namespace Rxmxnx.PInvoke.Extensions
             => new NullableReference<TValue>(instance);
 
         /// <summary>
-        /// Retrieves the instance object from an <see cref="IReferenceable{T}"/> object.
-        /// </summary>
-        /// <typeparam name="TValue">Type of internal object.</typeparam>
-        /// <param name="referenceable"><see cref="IReferenceable{T}"/> object.</param>
-        /// <returns>Instance <typeparamref name="TValue"/> object.</returns>
-        [Obsolete("Use Value property instead. It is not equivalent when the instance is null and the reference is not nullable.", true), ExcludeFromCodeCoverage]
-        public static TValue? GetInstance<TValue>(this IReferenceable<TValue> referenceable)
-            => referenceable != default ? referenceable.Reference : default;
-
-        /// <summary>
-        /// Retrieves the instance object from an <see cref="IReferenceable{T}"/> object.
-        /// </summary>
-        /// <typeparam name="TValue">Type of internal value.</typeparam>
-        /// <param name="referenceable"><see cref="IReferenceable{T}"/> object.</param>
-        /// <returns>Instance <see cref="Nullable{T}"/> value.</returns>
-        [Obsolete("Use Value property instead.", true), ExcludeFromCodeCoverage]
-        public static TValue? GetInstanceValue<TValue>(this IReferenceable<TValue> referenceable)
-            where TValue : struct
-            => referenceable != default ? referenceable.Reference : default(TValue?);
-
-        /// <summary>
-        /// Retrieves the instance object from an <see cref="IReferenceable{T}"/> object.
-        /// </summary>
-        /// <typeparam name="TValue">Type of internal value.</typeparam>
-        /// <param name="referenceable"><see cref="IReferenceable{T}"/> object.</param>
-        /// <returns>Instance <see cref="Nullable{T}"/> value.</returns>
-        [Obsolete("Use Value property instead.", true), ExcludeFromCodeCoverage]
-        public static TValue? GetInstanceValue<TValue>(this IReferenceable<TValue?> referenceable)
-            where TValue : struct
-            => referenceable != default ? referenceable.Reference : default;
-
-        /// <summary>
         /// Internal implementation of <see cref="InputValue{T}"/> for <see cref="ValueType"/> objects.
         /// </summary>
         /// <typeparam name="TValue"><see cref="ValueType"/> of the instance object.</typeparam>
         private record ValueInput<TValue> : InputValue<TValue>
             where TValue : struct
         {
+            /// <summary>
+            /// Internal method to set instance object.
+            /// </summary>
+            /// <param name="newValue">New <typeparamref name="TValue"/> object to set as instance object.</param>
             [ExcludeFromCodeCoverage]
-            internal override void SetInstance(in TValue newValue)
-                => throw new InvalidOperationException();
+            internal override void SetInstance(in TValue newValue) => throw new InvalidOperationException();
 
             /// <summary>
             /// Constructor.
@@ -114,12 +86,14 @@ namespace Rxmxnx.PInvoke.Extensions
         /// Internal implementation of <see cref="InputValue{T}"/> for nullable <see cref="ValueType"/> objects.
         /// </summary>
         /// <typeparam name="TValue"><see cref="ValueType"/> of the instance object.</typeparam>
-        private record NullableInput<TValue> : InputValue<TValue?>
-            where TValue : struct
+        private record NullableInput<TValue> : InputValue<TValue?> where TValue : struct
         {
+            /// <summary>
+            /// Internal method to set instance object.
+            /// </summary>
+            /// <param name="newValue">New <typeparamref name="TValue"/> object to set as instance object.</param>
             [ExcludeFromCodeCoverage]
-            internal override void SetInstance(in TValue? newValue)
-                => throw new InvalidOperationException();
+            internal override void SetInstance(in TValue? newValue) => throw new InvalidOperationException();
 
             /// <summary>
             /// Constructor.
@@ -140,14 +114,17 @@ namespace Rxmxnx.PInvoke.Extensions
             /// </summary>
             private readonly Object _writeLock = new();
 
+            /// <summary>
+            /// Internal method to set instance object.
+            /// </summary>
+            /// <param name="newValue">New <typeparamref name="TValue"/> object to set as instance object.</param>
             internal override void SetInstance(in TValue newValue)
             {
                 lock (this._writeLock)
                     base._instance = newValue;
             }
 
-            void IMutableReference<TValue>.SetInstance(TValue newValue)
-                => this.SetInstance(newValue);
+            void IMutableWrapper<TValue>.SetInstance(TValue newValue) => this.SetInstance(newValue);
 
             /// <summary>
             /// Constructor.
@@ -168,14 +145,17 @@ namespace Rxmxnx.PInvoke.Extensions
             /// </summary>
             private readonly Object _writeLock = new();
 
+            /// <summary>
+            /// Internal method to set instance object.
+            /// </summary>
+            /// <param name="newValue">New <typeparamref name="TValue"/> object to set as instance object.</param>
             internal override void SetInstance(in TValue? newValue)
             {
                 lock (this._writeLock)
                     base._instance = newValue;
             }
 
-            void IMutableReference<TValue?>.SetInstance(TValue? newValue)
-                => this.SetInstance(newValue);
+            void IMutableWrapper<TValue?>.SetInstance(TValue? newValue) => this.SetInstance(newValue);
 
             /// <summary>
             /// Constructor.

--- a/src/Rxmxnx.PInvoke.Extensions/Internal/InputValue.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/Internal/InputValue.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Runtime.CompilerServices;
-
-namespace Rxmxnx.PInvoke.Extensions.Internal
+﻿namespace Rxmxnx.PInvoke.Extensions.Internal
 {
     /// <summary>
     /// Creates an object which contains a single reference to an inmutable <typeparamref name="T"/> object.
     /// </summary>
     /// <typeparam name="T">Type of the referenced object.</typeparam>
-    internal abstract record InputValue<T> : IReferenceable<T>
+    internal abstract record InputValue<T> : IReferenceableWrapper<T>
     {
         /// <summary>
         /// Internal <typeparamref name="T"/> object.
@@ -23,26 +20,6 @@ namespace Rxmxnx.PInvoke.Extensions.Internal
         /// Wrapped <typeparamref name="T"/> object.
         /// </summary>
         public T Value => this._instance;
-
-        /// <summary>
-        /// Indicates whether the current object is equal to <typeparamref name="T"/> object.
-        /// </summary>
-        /// <param name="other">An object to compare with this object.</param>
-        /// <returns>
-        /// <see langword="true"/> if the current object is equal to the other parameter; otherwise, <see langword="false"/>.
-        /// </returns>
-        public Boolean Equals(T? other)
-            => Object.Equals(this._instance, other);
-
-        /// <summary>
-        /// Indicates whether the current object is equal to <see cref="IReferenceable{T}"/> object.
-        /// </summary>
-        /// <param name="other">An object to compare with this object.</param>
-        /// <returns>
-        /// <see langword="true"/> if the current object is equal to the other parameter; otherwise, <see langword="false"/>.
-        /// </returns>
-        public Boolean Equals(IReferenceable<T>? other)
-            => other != default && Unsafe.AreSame(ref Unsafe.AsRef(this.Reference), ref Unsafe.AsRef(other.Reference));
 
         /// <summary>
         /// Constructor.

--- a/src/Rxmxnx.PInvoke.Extensions/Internal/ValueRegion.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/Internal/ValueRegion.cs
@@ -4,50 +4,148 @@ using System.Runtime.CompilerServices;
 
 namespace Rxmxnx.PInvoke.Extensions.Internal
 {
-    internal abstract class ValueRegion<T>
-        where T : unmanaged
+    /// <summary>
+    /// This class represents an arbitrary memory region in which a sequence of 
+    /// <typeparamref name="T"/> values is found.
+    /// </summary>
+    /// <typeparam name="T">Unmanaged type of sequence item.</typeparam>
+    internal abstract class ValueRegion<T> where T : unmanaged
     {
+        /// <summary>
+        /// Gets an item from the memory region at the specified zero-based <paramref name="index"/>.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to get.</param>
+        /// <exception cref="IndexOutOfRangeException">
+        /// <paramref name="index"/> is less then zero or greater than or equal to 
+        /// memory region length.
+        /// </exception>
+        /// <returns>The element from the memory region.</returns>
         [IndexerName("Position")]
         public virtual T this[Int32 index] => this.AsSpan()[index];
+
+        /// <summary>
+        /// Copies the contents of this memory region into a new array.
+        /// </summary>
+        /// <returns>An array containing the data in the current memory region.</returns>
         public virtual T[] ToArray() => this.AsSpan().ToArray();
 
+        /// <summary>
+        /// Gets an array from this memory region.
+        /// </summary>
+        /// <returns>An array containing the data in the current memory region.</returns>
         protected virtual T[]? AsArray() => default;
+        /// <summary>
+        /// Creates a new read-only span over this memory region.
+        /// </summary>
+        /// <returns>The read-only span representation of the memory region.</returns>
         protected abstract ReadOnlySpan<T> AsSpan();
 
+        /// <summary>
+        /// Returns an enumerator for this memory region.
+        /// </summary>
+        /// <returns>An enumerator for this memory region.</returns>
         public ReadOnlySpan<T>.Enumerator GetEnumerator() => this.AsSpan().GetEnumerator();
 
+        /// <summary>
+        /// Implicit operator. <see cref="ValueRegion{T}"/> -> <see cref="ReadOnlySpan{T}"/>.
+        /// </summary>
+        /// <param name="arrayWrapper"><see cref="ValueRegion{T}"/> instance.</param>
         public static implicit operator ReadOnlySpan<T>(ValueRegion<T> arrayWrapper) => arrayWrapper.AsSpan();
+        /// <summary>
+        /// Implicit operator. <see cref="ValueRegion{T}"/> -> Array of <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="arrayWrapper"><see cref="ValueRegion{T}"/> instance.</param>
         public static implicit operator T[]?(ValueRegion<T> arrayWrapper) => arrayWrapper.AsArray();
 
-        public static ValueRegion<T> Create([DisallowNull] T[] array) => new ManagedWrapper(array);
-        public static ValueRegion<T> Create(IntPtr ptr, Int32 length)
-            => !ptr.IsZero() && length != default ? new NativeWrapper(ptr, length) : NativeWrapper.Empty;
+        /// <summary>
+        /// Creates a new <see cref="ValueRegion{T}"/> instance from an array of 
+        /// <typeparamref name="T"/> values.
+        /// </summary>
+        /// <param name="array">Array of <typeparamref name="T"/> values.</param>
+        /// <returns>A new <see cref="ValueRegion{T}"/> instance.</returns>
+        public static ValueRegion<T> Create([DisallowNull] T[] array) => new ManagedRegion(array);
+        /// <summary>
+        /// Creates a new <see cref="ValueRegion{T}"/> instance from a pointer to memory region and 
+        /// the amount of values in sequence.
+        /// </summary>
+        /// <param name="ptr">Pointer to memory region.</param>
+        /// <param name="count">Amount of values in sequence.</param>
+        /// <returns>A new <see cref="ValueRegion{T}"/> instance.</returns>
+        public static ValueRegion<T> Create(IntPtr ptr, Int32 count)
+            => !ptr.IsZero() && count != default ? new NativeRegion(ptr, count) : NativeRegion.Empty;
 
-        private sealed class ManagedWrapper : ValueRegion<T>
+        /// <summary>
+        /// This class represents a memory region in which an array of <typeparamref name="T"/> 
+        /// values is found.
+        /// </summary>
+        private sealed class ManagedRegion : ValueRegion<T>
         {
+            /// <summary>
+            /// Internal <typeparamref name="T"/> array.
+            /// </summary>
             private readonly T[] _array;
 
+            /// <summary>
+            /// Gets an item from the memory region at the specified zero-based <paramref name="index"/>.
+            /// </summary>
+            /// <param name="index">The zero-based index of the element to get.</param>
+            /// <exception cref="IndexOutOfRangeException">
+            /// <paramref name="index"/> is less then zero or greater than or equal to 
+            /// memory region length.
+            /// </exception>
+            /// <returns>The element from the memory region.</returns>
             public override T this[Int32 index] => this._array[index];
 
-            public ManagedWrapper([DisallowNull] T[] array) => this._array = array;
+            /// <summary>
+            /// Constructor.
+            /// </summary>
+            /// <param name="array"><typeparamref name="T"/> array instance.</param>
+            public ManagedRegion([DisallowNull] T[] array) => this._array = array;
 
+            /// <summary>
+            /// Gets an array from this memory region.
+            /// </summary>
+            /// <returns>An array containing the data in the current memory region.</returns>
             protected override T[] AsArray() => this._array;
-            protected override ReadOnlySpan<T> AsSpan() => this._array;
+            /// <summary>
+            /// Creates a new read-only span over this memory region.
+            /// </summary>
+            /// <returns>The read-only span representation of the memory region.</returns>
+            protected override ReadOnlySpan<T> AsSpan() => this._array.AsSpan();
         }
 
-        private sealed class NativeWrapper : ValueRegion<T>
+        /// <summary>
+        /// This class represents a native memory region in which a sequence of <typeparamref name="T"/> 
+        /// values is found.
+        /// </summary>
+        private sealed class NativeRegion : ValueRegion<T>
         {
-            public static readonly NativeWrapper Empty = new(IntPtr.Zero, default);
+            public static readonly NativeRegion Empty = new(IntPtr.Zero, default);
 
+            /// <summary>
+            /// Pointer to native memory region.
+            /// </summary>
             private readonly IntPtr _ptr;
+            /// <summary>
+            /// Length of <typeparamref name="T"/> sequence.
+            /// </summary>
             private readonly Int32 _length;
 
-            public NativeWrapper(IntPtr ptr, Int32 length)
+            /// <summary>
+            /// Constructor.
+            /// </summary>
+            /// <param name="ptr">Pointer to native memory region.</param>
+            /// <param name="length">Length of <typeparamref name="T"/> sequence.</param>
+            public NativeRegion(IntPtr ptr, Int32 length)
             {
                 this._ptr = ptr;
                 this._length = !this._ptr.Equals(IntPtr.Zero) ? length : default;
             }
 
+            /// <summary>
+            /// Creates a new read-only span over this memory region.
+            /// </summary>
+            /// <returns>The read-only span representation of the memory region.</returns>
             protected override ReadOnlySpan<T> AsSpan() => this._ptr.AsReadOnlySpan<T>(this._length);
         }
     }


### PR DESCRIPTION
* Default implementation of IEquatable<T>.Equals(T? other) in IWrapper<T>.
* Default implementation of IEquatable<IReferenceable<T>>.Equals(IReferenceable<T>? other) in IReferenceable<T>.
* Independence of IReferenceable<T> from IWrapper<T>
* IMutableWrapper<T> and IReferenceableWrapper<T>.
* Remove deprecated methods in InputValue.
* Nullable fixes.
* Documentation improvements.