### PR TITLE
Fixes on CStringSequence constructor and test improvements.

### DIFF
--- a/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/AsSpanTest.cs
+++ b/src/Rxmxnx.PInvoke.Extensions.Tests/CStringSequenceTest/AsSpanTest.cs
@@ -16,8 +16,19 @@ namespace Rxmxnx.PInvoke.Extensions.Tests.CStringSequenceTest
         [Fact]
         internal void NormalTest()
         {
-            CString[] localValues = TestUtilities.SharedFixture.Create<String[]>().Select(x => (CString)x).ToArray();
-            String[] strValue = TestUtilities.SharedFixture.Create<String[]>();
+            Random random = new Random();
+            CString[] localValues = TestUtilities.SharedFixture.CreateMany<String>(100).Select(x =>
+            {
+                Int32 start = random.Next(0, x.Length);
+                Int32 end = random.Next(start, x.Length);
+                return (CString)x[start..end];
+            }).ToArray();
+            String[] strValue = TestUtilities.SharedFixture.CreateMany<String>(100).Select(x =>
+            {
+                Int32 start = random.Next(0, x.Length);
+                Int32 end = random.Next(start, x.Length);
+                return x[start..end];
+            }).ToArray();
             Byte[][] bytes = strValue.Select(x => Encoding.UTF8.GetBytes(x)).ToArray();
             GCHandle[] handles = TestUtilities.Alloc(bytes);
             try

--- a/src/Rxmxnx.PInvoke.Extensions.Tests/CStringTest/OperatorsTest.cs
+++ b/src/Rxmxnx.PInvoke.Extensions.Tests/CStringTest/OperatorsTest.cs
@@ -278,10 +278,12 @@ namespace Rxmxnx.PInvoke.Extensions.Tests.CStringTest
 
         private static void AssertReferenceEquality(ReadOnlySpan<Byte> span, CString cstr, Boolean clone)
         {
+            IntPtr ptr = span.AsIntPtr();
             ReadOnlySpan<Byte> cstrSpan = cstr;
+            IntPtr cstrSpanPtr = cstrSpan.AsIntPtr();
             Byte[] bytes = cstr.ToArray();
 
-            Assert.Equal(!clone, span.AsIntPtr().Equals(cstrSpan.AsIntPtr()));
+            Assert.Equal(!clone, ptr.Equals(cstrSpanPtr));
             Assert.Equal(span.Length, cstrSpan.Length);
 
             Int32 index = 0;

--- a/src/Rxmxnx.PInvoke.Extensions/CStringSequence.cs
+++ b/src/Rxmxnx.PInvoke.Extensions/CStringSequence.cs
@@ -179,7 +179,7 @@ namespace Rxmxnx.PInvoke.Extensions
                     ReadOnlySpan<Char> chars = (span.AsIntPtr() + offset).AsReadOnlySpan<Char>(charSpanLength);
                     foreach (Char c in chars)
                         strBuild.Append(c);
-                    previous = charSpanLength % sizeOfChar != 0 ? cstr[^1] : default;
+                    previous = desiredSize % sizeOfChar != 0 ? cstr[^1] : default;
                 }
             }
         }


### PR DESCRIPTION
There was a bug in CStringSequence.CopyText that duplicates the last UTF-8 character in CString when the length of CString is not divisible by four.
We need mark previous release as obsolete.

Additionally, the unit test of the constructor was improved, guaranteeing that the generated strings are of different lengths.