### PR TITLE
Fix documentation

### DIFF
--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/CString/StringConcat.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/CString/StringConcat.cs
@@ -13,7 +13,7 @@ public partial class CString
     /// If any element within <paramref name="values"/> is <see langword="null"/>, it is ignored
     /// during concatenation.
     /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="values"/> is <see langword="null"/>.</exception>
     public static CString Concat(params String?[] values)
     {
         ArgumentNullException.ThrowIfNull(values);
@@ -36,7 +36,7 @@ public partial class CString
     /// and concatenates each element into a single <see cref="CString"/> instance.
     /// If any element within <paramref name="values"/> is <see langword="null"/>, it is ignored during concatenation.
     /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="values"/> is <see langword="null"/>.</exception>
     public static Task<CString> ConcatAsync(params String?[] values) => ConcatAsync(CancellationToken.None, values);
     /// <summary>
     /// Asynchronously concatenates the elements of a specified <see cref="String"/>
@@ -55,7 +55,7 @@ public partial class CString
     /// If any element within <paramref name="values"/> is <see langword="null"/>, it is ignored during concatenation.
     /// The operation can be cancelled at any time by triggering the <paramref name="cancellationToken"/>.
     /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="values"/> is <see langword="null"/>.</exception>
     public static async Task<CString> ConcatAsync(CancellationToken cancellationToken, params String?[] values)
     {
         ArgumentNullException.ThrowIfNull(values);

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/CStringSequence/Indexer.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/CStringSequence/Indexer.cs
@@ -40,7 +40,7 @@ public partial class CStringSequence : IReadOnlyList<CString>, IEnumerableSequen
     /// The zero-based index at which the subsequence starts.
     /// </param>
     /// <returns>A <see cref="CStringSequence"/> that is a subsequence of this instance.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="length"/> is out of range.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="startIndex"/> is out of range.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public CStringSequence Slice(Int32 startIndex) => this[startIndex..this._lengths.Length];
     /// <summary>

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/Internal/BinaryConcatenator.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/Internal/BinaryConcatenator.cs
@@ -19,7 +19,7 @@ internal abstract partial class BinaryConcatenator<T> : IDisposable, IAsyncDispo
     /// </summary>
     public T? Separator => this._separator;
 
-    //// <summary>
+    /// <summary>
     /// Constructs a new instance of the BinaryConcatenator class.
     /// </summary>
     /// <param name="separator">The separator for the concatenation.</param>

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/Internal/DecodedRune.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/Internal/DecodedRune.cs
@@ -146,11 +146,12 @@ internal sealed class DecodedRune : IWrapper<Rune>
     }
 
     /// <summary>
-    /// Returns a value that indicates whether two <see cref="DecodedRune"/> instances have the same <see cref="Rune"/> value.
+    /// Defines an implicit conversion from a nullable <see cref="DecodedRune"/> to a <see cref="Rune"/>.
     /// </summary>
+    /// <param name="rune">The nullable <see cref="DecodedRune"/> value to convert.</param>
     /// <returns>
-    /// <see langword="true"/> if the <see cref="Rune"/> value of <paramref name="left"/> and <paramref name="right"/> is the same;
-    /// otherwise, <see langword="false"/>.
+    /// The converted <see cref="Rune"/> value if the input <paramref name="rune"/> is not <see langword="null"/>;
+    /// otherwise, returns the default value of <see cref="Rune"/>.
     /// </returns>
     public static implicit operator Rune(DecodedRune? rune) => rune?.Value ?? default;
 

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/Internal/Utf8Comparator.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/Internal/Utf8Comparator.cs
@@ -74,7 +74,7 @@ internal abstract partial class Utf8Comparator<TChar> where TChar : unmanaged
         this._optionsIgnoreCase = CompareOptions.IgnoreCase;
     }
 
-    // <summary>
+    /// <summary>
     /// Compares two specified texts using the specified rules and returns an integer that indicates their relative position in
     /// the sort order.
     /// </summary>

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/Rxmxnx.PInvoke.CString.Intermediate.csproj
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/Rxmxnx.PInvoke.CString.Intermediate.csproj
@@ -9,6 +9,9 @@
     <Deterministic>true</Deterministic>
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <DocumentationFile>./$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ExcludeXmlAssemblyFiles>false</ExcludeXmlAssemblyFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/CommonDelegates.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/CommonDelegates.cs
@@ -247,10 +247,13 @@ public delegate TResult ReadOnlyFixedReferenceFunc<T, in TArg, out TResult>(in I
 /// <param name="method">An instance of the fixed method delegate.</param>
 public delegate void FixedMethodAction<T>(in IFixedMethod<T> method) where T : Delegate;
 /// <summary>
-/// Encapsulates a method that takes an instance of <see cref="IFixedMethod{T}"/>.
+/// Encapsulates a method that takes an instance of <see cref="IFixedMethod{T}"/> and a state object of type
+/// <typeparamref name="TArg"/>.
 /// </summary>
 /// <typeparam name="T">The type of the fixed method delegate.</typeparam>
+/// <typeparam name="TArg">The type of the state object.</typeparam>
 /// <param name="method">An instance of the fixed method delegate.</param>
+/// <param name="arg">A state object of type TArg.</param>
 public delegate void FixedMethodAction<T, in TArg>(in IFixedMethod<T> method, TArg arg) where T : Delegate;
 
 /// <summary>

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/IMutableReference.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/IMutableReference.cs
@@ -15,8 +15,8 @@ public interface IMutableReference : IMutableWrapper
     /// The newly created object wraps a value of <typeparamref name="TValue"/> type provided by <paramref name="value"/>.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static new IMutableReference<TValue> Create<TValue>(in TValue instance = default!) where TValue : struct
-        => IMutableReference<TValue>.Create(instance);
+    public static new IMutableReference<TValue> Create<TValue>(in TValue value = default!) where TValue : struct
+        => IMutableReference<TValue>.Create(value);
     /// <summary>
     /// Creates a new instance of an object that implements <see cref="IMutableReference{TValue}"/> interface.
     /// </summary>
@@ -28,20 +28,20 @@ public interface IMutableReference : IMutableWrapper
     /// <paramref name="value"/>.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static new IMutableReference<TValue?> CreateNullable<TValue>(in TValue? instance = default) where TValue : struct
-        => IMutableReference<TValue?>.Create(instance);
+    public static new IMutableReference<TValue?> CreateNullable<TValue>(in TValue? value = default) where TValue : struct
+        => IMutableReference<TValue?>.Create(value);
     /// <summary>
     /// Creates a new instance of an object that implements <see cref="IMutableReference{TObject}"/> interface.
     /// </summary>
     /// <typeparam name="TObject">The type of the object to be wrapped.</typeparam>
-    /// <param name="instance">The instance to be wrapped.</param>
+    /// <param name="value">The instance to be wrapped.</param>
     /// <returns>An instance of an object that implements <see cref="IMutableReference{TObject}"/> interface.</returns>
     /// <remarks>
-    /// The newly created object wraps an object of <typeparamref name="TObject"/> type provided by <paramref name="instance"/>.
+    /// The newly created object wraps an object of <typeparamref name="TObject"/> type provided by <paramref name="value"/>.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static new IMutableReference<TObject> CreateObject<TObject>(TObject instance) where TObject : class
-        => IMutableReference<TObject>.Create(instance)!;
+    public static new IMutableReference<TObject> CreateObject<TObject>(TObject value) where TObject : class
+        => IMutableReference<TObject>.Create(value)!;
 }
 
 /// <summary>

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedContext.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedContext.cs
@@ -54,7 +54,6 @@ internal unsafe sealed class FixedContext<T> : FixedMemory, IFixedContext<T>, IE
     /// </summary>
     /// <param name="ptr">The pointer to the fixed memory block.</param>
     /// <param name="count">The number of items of type <typeparamref name="T"/> in the memory block.</param>
-    /// <param name="isReadOnly">A value that indicates whether the memory block is read-only.</param>
     public FixedContext(void* ptr, Int32 count) : base(ptr, count * sizeof(T))
     {
         this._count = count;
@@ -88,6 +87,8 @@ internal unsafe sealed class FixedContext<T> : FixedMemory, IFixedContext<T>, IE
     /// Output. Provides a fixed offset that represents the remaining portion of memory that is not included in the new context.
     /// This is calculated based on the size of the new type compared to the size of the original memory block.
     /// </param>
+    /// <param name="isReadOnly">Indicates whether the transformation operation should be performed as a read-only operation.</param>
+    /// <returns>
     /// A new instance of FixedContext for the destination type, which represents a fixed memory context of the new type.
     /// </returns>
     /// <remarks>

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ReadOnlyFixedReference.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ReadOnlyFixedReference.cs
@@ -42,8 +42,10 @@ internal unsafe sealed class ReadOnlyFixedReference<T> : ReadOnlyFixedMemory, IR
     /// Transforms the current memory reference into a different type and provides a fixed offset that represents the remaining portion of memory not included in the newly formed reference.
     /// </summary>
     /// <typeparam name="TDestination">The type into which the current memory reference should be transformed.</typeparam>
-    /// <param name="fixedOffset">Output. Provides a fixed offset that represents the remaining portion of memory that is not included in the new reference. This is calculated based on the size of the new type compared to the size of the original reference.</param>
-    /// <param name="isReadOnly">Indicates whether the transformation operation should be performed as a read-only operation.</param>
+    /// <param name="fixedOffset">
+    /// Output. Provides a fixed offset that represents the remaining portion of memory that is not included in the new reference.
+    /// This is calculated based on the size of the new type compared to the size of the original reference.
+    /// </param>
     /// <returns>A new instance of FixedReference for the destination type, which represents a fixed memory reference of the new type.</returns>
     /// <exception cref="InsufficientMemoryException">Thrown when the size of the current reference is not sufficient to accommodate the new type. For example, if an attempt is made to transform a 2-byte reference into a 4-byte type.</exception>
     public ReadOnlyFixedReference<TDestination> GetTransformation<TDestination>(out ReadOnlyFixedOffset fixedOffset) where TDestination : unmanaged

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Rxmxnx.PInvoke.Common.Intermediate.csproj
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Rxmxnx.PInvoke.Common.Intermediate.csproj
@@ -9,6 +9,9 @@
     <Deterministic>true</Deterministic>
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <DocumentationFile>./$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ExcludeXmlAssemblyFiles>false</ExcludeXmlAssemblyFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/BinaryExtensions.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/BinaryExtensions.cs
@@ -37,11 +37,11 @@ public static partial class BinaryExtensions
         return MemoryMarshal.Read<T>(result);
     }
     /// <summary>
-    /// Retrieves a read-only reference to a <typeparamref name="T"/> value from the given read-only byte span.
+    /// Retrieves a read-only reference to a <typeparamref name="TValue"/> value from the given read-only byte span.
     /// </summary>
-    /// <typeparam name="T">The type of the value to be referenced.</typeparam>
+    /// <typeparam name="TValue">The type of the value to be referenced.</typeparam>
     /// <param name="span">The source read-only byte span.</param>
-    /// <returns>A read-only reference to the <typeparamref name="T"/> value.</returns>
+    /// <returns>A read-only reference to the <typeparamref name="TValue"/> value.</returns>
     /// <exception cref="InsufficientMemoryException">
     /// Thrown if the size of the binary span is less than the size of the type <typeparamref name="TValue"/>.
     /// </exception>
@@ -49,17 +49,17 @@ public static partial class BinaryExtensions
     /// Thrown if the size of the binary span is greater than the size of the type <typeparamref name="TValue"/>.
     /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly T AsValue<T>(this ReadOnlySpan<Byte> span) where T : unmanaged
+    public static ref readonly TValue AsValue<TValue>(this ReadOnlySpan<Byte> span) where TValue : unmanaged
     {
-        ValidationUtilities.ThrowIfInvalidBinarySpanSize<T>(span);
-        return ref MemoryMarshal.Cast<Byte, T>(span)[0];
+        ValidationUtilities.ThrowIfInvalidBinarySpanSize<TValue>(span);
+        return ref MemoryMarshal.Cast<Byte, TValue>(span)[0];
     }
     /// <summary>
-    /// Retrieves a reference to a <typeparamref name="T"/> value from the given byte span.
+    /// Retrieves a reference to a <typeparamref name="TValue"/> value from the given byte span.
     /// </summary>
-    /// <typeparam name="T">The type of the value to be referenced.</typeparam>
+    /// <typeparam name="TValue">The type of the value to be referenced.</typeparam>
     /// <param name="span">The source byte span.</param>
-    /// <returns>A reference to the <typeparamref name="T"/> value.</returns>
+    /// <returns>A reference to the <typeparamref name="TValue"/> value.</returns>
     /// <exception cref="InsufficientMemoryException">
     /// Thrown if the size of the binary span is less than the size of the type <typeparamref name="TValue"/>.
     /// </exception>
@@ -67,10 +67,10 @@ public static partial class BinaryExtensions
     /// Thrown if the size of the binary span is greater than the size of the type <typeparamref name="TValue"/>.
     /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref T AsValue<T>(this Span<Byte> span) where T : unmanaged
+    public static ref TValue AsValue<TValue>(this Span<Byte> span) where TValue : unmanaged
     {
-        ValidationUtilities.ThrowIfInvalidBinarySpanSize<T>(span);
-        return ref MemoryMarshal.Cast<Byte, T>(span)[0];
+        ValidationUtilities.ThrowIfInvalidBinarySpanSize<TValue>(span);
+        return ref MemoryMarshal.Cast<Byte, TValue>(span)[0];
     }
 
     /// <summary>

--- a/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/PointerExtensions.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/PointerExtensions.cs
@@ -88,7 +88,7 @@ public static partial class PointerExtensions
     /// <summary>
     /// Creates a <see cref="String"/> instance from a <see cref="Char"/> pointer, interpreting the contents as UTF-16 text.
     /// </summary>
-    /// <param name="chrPtr">A pointer to the first character of the UTF-16 text in memory.</param>
+    /// <param name="uptr">A pointer to the first character of the UTF-16 text in memory.</param>
     /// <param name="length">The number of <see cref="Char"/> elements to include in the resulting string, 
     /// starting from the pointer. If this value is zero, the function reads until the first null character.</param>
     /// <returns>A <see cref="String"/> representation of the UTF-16 text in memory.</returns>

--- a/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate.csproj
+++ b/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate.csproj
@@ -9,6 +9,9 @@
     <Deterministic>true</Deterministic>
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <DocumentationFile>./$(AssemblyName).xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ExcludeXmlAssemblyFiles>false</ExcludeXmlAssemblyFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/UnmanagedValueExtensions.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/UnmanagedValueExtensions.cs
@@ -11,7 +11,6 @@ public static partial class UnmanagedValueExtensions
     /// <typeparam name="T">The type of value. This must be an <see langword="unmanaged"/> value type.</typeparam>
     /// <param name="value">The value to convert.</param>
     /// <returns>An array of bytes that represent the input value.</returns>
-    /// <remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe Byte[] ToBytes<T>(this T value) where T : unmanaged
         => NativeUtilities.ToBytes(value);


### PR DESCRIPTION
In the previous version, many XML comments in the documentation were not well-formed. We need to fix that.