### PR TITLE
RentFixed extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ interaction between .NET and native P/Invoke methods.
 
 ## Features
 
-- **UTF-8/ASCII String Handling**: Seamlessly work with UTF-8 encoded strings in interop contexts. [More info](src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md)
+- **UTF-8/ASCII String Handling**: Seamlessly work with UTF-8 encoded strings in interop
+  contexts. [More info](src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md)
 - **Managed Buffers**: Dynamically allocate object references on the stack with minimal
   effort.  [More info](src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/README.md)
 - **Safe Memory Manipulation**: Eliminate direct pointer manipulation and unsafe code requirements.
@@ -2638,6 +2639,24 @@ This class allows to allocate buffers on stack if possible.
   Registers `T?` buffer.
 
   **Note:** `T` is `struct`. `TBuffer` is `struct` and `IManagedBuffer<T?>`.
+  </details>
+- <details>
+  <summary>PrepareBinaryBuffer(UInt16)</summary>
+  Prepares the binary buffer metadata needed to allocate given number of objects.
+  </details>
+- <details>
+  <summary>PrepareBinaryBuffer&lt;T&gt;(UInt16)</summary>
+
+  Prepares the binary buffer metadata needed to allocate given number of `T` items.
+
+  **Note:** `T` is `struct`.
+  </details>
+- <details>
+  <summary>PrepareBinaryBufferNullable&lt;T&gt;()</summary>
+
+  Prepares the binary buffer metadata needed to allocate given number of `T?` items.
+
+  **Note:** `T` is `struct`.
   </details>
 
 </details>

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ interaction between .NET and native P/Invoke methods.
   contexts. [More info](src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md)
 - **Managed Buffers**: Dynamically allocate object references on the stack with minimal
   effort.  [More info](src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/README.md)
-- **Safe Memory Manipulation**: Eliminate direct pointer manipulation and unsafe code requirements.
+- **Safe Memory Manipulation**: Eliminate direct pointer manipulation and unsafe code
+  requirements. [More info](src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/README.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2487,6 +2487,18 @@ Set of extensions for basic operations with `String` instances.
 Set of extensions for basic operations with `unmanaged` values.
 
 - <details>
+  <summary>RentFixed&lt;T&gt;(this ArrayPool&lt;T&gt;, Int32, Boolean)</summary>
+
+  Rents and pins an array of minimum number of `T` elements from given array pool,
+  ensuring a safe context for accessing the fixed memory.
+  </details>
+- <details>
+  <summary>RentFixed&lt;T&gt;(this ArrayPool&lt;T&gt;, Int32, Boolean, out Int32)</summary>
+
+  Rents and pins an array of minimum number of `T` elements from given array pool,
+  ensuring a safe context for accessing the fixed memory.
+  </details>
+- <details>
   <summary>ToBytes&lt;T&gt;(this T)</summary>
 
   Converts a given `unmanaged` value of type `T` into an array of `Byte`.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ interaction between .NET and native P/Invoke methods.
 
 ## Features
 
-- **UTF-8/ASCII String Handling**: Seamlessly work with UTF-8 encoded strings in interop contexts.
-- **Managed Buffers**: Dynamically allocate object references on the stack with minimal effort.
+- **UTF-8/ASCII String Handling**: Seamlessly work with UTF-8 encoded strings in interop contexts. [More info](src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md)
+- **Managed Buffers**: Dynamically allocate object references on the stack with minimal
+  effort.  [More info](src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/README.md)
 - **Safe Memory Manipulation**: Eliminate direct pointer manipulation and unsafe code requirements.
 
 ---

--- a/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager.cs
@@ -124,4 +124,38 @@ public static partial class BufferManager
 		if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>()) return;
 		MetadataManager<T?>.RegisterBuffer<TBuffer>();
 	}
+	/// <summary>
+	/// Prepares the binary buffer metadata needed to allocate <paramref name="count"/> objects.
+	/// </summary>
+	/// <param name="count">Amount of items in required buffer.</param>
+	/// <exception cref="InvalidOperationException">Throw if missing metadata for any buffer component.</exception>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static void PrepareBinaryBuffer(UInt16 count) => MetadataManager<Object>.PrepareBinaryMetadata(count);
+	/// <summary>
+	/// Prepares the binary buffer metadata needed to allocate <paramref name="count"/> <typeparamref name="T"/> items.
+	/// </summary>
+	/// <typeparam name="T">Type of items in the buffer.</typeparam>
+	/// <param name="count">Amount of items in required buffer.</param>
+	/// <exception cref="InvalidOperationException">Throw if missing metadata for any buffer component.</exception>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static void PrepareBinaryBuffer<T>(UInt16 count) where T : struct
+	{
+		// If unmanaged type, stackalloc should be used.
+		if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>()) return;
+		MetadataManager<T>.PrepareBinaryMetadata(count);
+	}
+	/// <summary>
+	/// Prepares the binary buffer metadata needed to allocate <paramref name="count"/> nullable <typeparamref name="T"/>
+	/// items.
+	/// </summary>
+	/// <typeparam name="T">Type of nullable items in the buffer.</typeparam>
+	/// <param name="count">Amount of items in required buffer.</param>
+	/// <exception cref="InvalidOperationException">Throw if missing metadata for any buffer component.</exception>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static void PrepareBinaryBufferNullable<T>(UInt16 count) where T : struct
+	{
+		// If unmanaged type, stackalloc should be used.
+		if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>()) return;
+		MetadataManager<T?>.PrepareBinaryMetadata(count);
+	}
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager.cs
@@ -12,8 +12,9 @@ public static partial class BufferManager
 	public static Boolean BufferAutoCompositionEnabled
 	{
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		get => !AotInfo.IsReflectionDisabled && 
-			(!AppContext.TryGetSwitch("PInvoke.DisableBufferAutoComposition", out Boolean disable) || !disable);
+		get
+			=> !AotInfo.IsReflectionDisabled &&
+				(!AppContext.TryGetSwitch("PInvoke.DisableBufferAutoComposition", out Boolean disable) || !disable);
 	}
 
 	/// <summary>
@@ -106,7 +107,11 @@ public static partial class BufferManager
 	/// <typeparam name="TBuffer">Type of <typeparamref name="T"/> buffer.</typeparam>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static void Register<T, TBuffer>() where TBuffer : struct, IManagedBuffer<T> where T : struct
-		=> MetadataManager<T>.RegisterBuffer<TBuffer>();
+	{
+		// If unmanaged type, stackalloc should be used.
+		if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>()) return;
+		MetadataManager<T>.RegisterBuffer<TBuffer>();
+	}
 	/// <summary>
 	/// Registers <typeparamref name="T"/> buffer.
 	/// </summary>
@@ -114,5 +119,9 @@ public static partial class BufferManager
 	/// <typeparam name="TBuffer">Type of <see name="Nullable{T}"/> buffer.</typeparam>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static void RegisterNullable<T, TBuffer>() where TBuffer : struct, IManagedBuffer<T?> where T : struct
-		=> MetadataManager<T?>.RegisterBuffer<TBuffer>();
+	{
+		// If unmanaged type, stackalloc should be used.
+		if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>()) return;
+		MetadataManager<T?>.RegisterBuffer<TBuffer>();
+	}
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager/MetadataManager.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager/MetadataManager.cs
@@ -24,6 +24,30 @@ public static partial class BufferManager
 			return MetadataManager<T>.GetBinaryMetadata(count, true);
 		}
 		/// <summary>
+		/// Prepares internal metadata cache for allocations of <see cref="count"/> items.
+		/// </summary>
+		/// <param name="count">Amount of items in required buffer.</param>
+		/// <exception cref="InvalidOperationException">Throw if missing metadata for any buffer component.</exception>
+		public static void PrepareBinaryMetadata(UInt16 count)
+		{
+			Type typeofT = typeof(T);
+			BufferTypeMetadata<T>? metadata = default;
+			foreach (UInt16 comp in BufferManager.GetBinaryComponents(count))
+			{
+				BufferTypeMetadata<T>? compMetadata = MetadataManager<T>.GetFundamental(comp);
+				ValidationUtilities.ThrowIfNullMetadata(typeofT, comp, compMetadata is null);
+				if (metadata is null)
+				{
+					metadata = compMetadata;
+					continue;
+				}
+
+				UInt16 composeSize = (UInt16)(comp + metadata.Size);
+				metadata = MetadataManager<T>.GetBinaryMetadata(composeSize, false);
+				ValidationUtilities.ThrowIfNullMetadata(typeofT, composeSize, metadata is null);
+			}
+		}
+		/// <summary>
 		/// Creates <see cref="BufferTypeMetadata{T}"/> for <see cref="Composite{TBufferA,TBufferB,T}"/>.
 		/// </summary>
 		/// <param name="typeofA">The type of low buffer.</param>

--- a/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager/MetadataManager.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager/MetadataManager.cs
@@ -24,7 +24,7 @@ public static partial class BufferManager
 			return MetadataManager<T>.GetBinaryMetadata(count, true);
 		}
 		/// <summary>
-		/// Prepares internal metadata cache for allocations of <see cref="count"/> items.
+		/// Prepares internal metadata cache for allocations of <paramref name="count"/> items.
 		/// </summary>
 		/// <param name="count">Amount of items in required buffer.</param>
 		/// <exception cref="InvalidOperationException">Throw if missing metadata for any buffer component.</exception>

--- a/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager/Private.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager/Private.cs
@@ -1,6 +1,7 @@
 namespace Rxmxnx.PInvoke;
 
 [SuppressMessage(SuppressMessageConstants.CSharpSquid, SuppressMessageConstants.CheckIdS3011)]
+[SuppressMessage(SuppressMessageConstants.CSharpSquid, SuppressMessageConstants.CheckIdS6640)]
 public static partial class BufferManager
 {
 	/// <summary>

--- a/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager/Private.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager/Private.cs
@@ -343,6 +343,19 @@ public static partial class BufferManager
 	/// <returns>The maximum value in the given binary space.</returns>
 	private static UInt16 GetMaxValue(UInt16 space) => (UInt16)(space * 2 - 1);
 	/// <summary>
+	/// Retrieves the components sizes for given <paramref name="count"/>.
+	/// </summary>
+	/// <param name="count">Amount of items in required buffer.</param>
+	/// <returns>Enumeration of components sizes.</returns>
+	private static IEnumerable<UInt16> GetBinaryComponents(UInt16 count)
+	{
+		for (UInt16 i = 0; i < 16; i++)
+		{
+			UInt16 mask = (UInt16)(1 << i);
+			if ((count & mask) != 0) yield return mask;
+		}
+	}
+	/// <summary>
 	/// Allocates a stack buffer of size of <paramref name="count"/> elements.
 	/// </summary>
 	/// <typeparam name="T">The type of items in the buffer.</typeparam>

--- a/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager/TransformationState.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/BufferManager/TransformationState.cs
@@ -21,9 +21,9 @@ public static partial class BufferManager
 		/// <param name="state">State object.</param>
 		public static void Execute(ScopedBuffer<Object> buffer, TransformationState<T> state)
 		{
-			Span<T> span =
-				MemoryMarshal.CreateSpan(ref Unsafe.As<Object, T>(ref MemoryMarshal.GetReference(buffer.Span)),
-				                         buffer.Span.Length);
+			ref Object refObject = ref MemoryMarshal.GetReference(buffer.Span);
+			ref T refT = ref Unsafe.As<Object, T>(ref refObject);
+			Span<T> span = MemoryMarshal.CreateSpan(ref refT, buffer.Span.Length);
 			ScopedBuffer<T> bufferT = new(span, !buffer.InStack, buffer.FullLength, buffer.BufferMetadata);
 			state._action(bufferT);
 		}
@@ -49,9 +49,9 @@ public static partial class BufferManager
 		/// <param name="state">State object.</param>
 		public static TResult Execute(ScopedBuffer<Object> buffer, TransformationState<T, TResult> state)
 		{
-			Span<T> span =
-				MemoryMarshal.CreateSpan(ref Unsafe.As<Object, T>(ref MemoryMarshal.GetReference(buffer.Span)),
-				                         buffer.Span.Length);
+			ref Object refObject = ref MemoryMarshal.GetReference(buffer.Span);
+			ref T refT = ref Unsafe.As<Object, T>(ref refObject);
+			Span<T> span = MemoryMarshal.CreateSpan(ref refT, buffer.Span.Length);
 			ScopedBuffer<T> bufferT = new(span, !buffer.InStack, buffer.FullLength, buffer.BufferMetadata);
 			return state._func(bufferT);
 		}

--- a/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/README.md
+++ b/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/README.md
@@ -73,6 +73,14 @@ reference type Composite(2<sup>1</sup>, 2<sup>3</sup>, `Object`).
 </Directives>
 ```
 
+### Preparation
+
+Binary buffers can be statically prepared to allocate a specific number of elements using auto-composition to cache the
+buffer metadata with the required size.
+
+**Note:** It is ideal for scenarios where buffer allocation needs to occur as transparently as possible, without
+requiring additional allocations.
+
 ---
 
 ## Non-Binary Buffers
@@ -92,3 +100,7 @@ There are three buffer registration options:
 1. For `Object` type.
 2. For generic `struct` type.
 3. For generic nullable `struct` type.
+
+## Binary buffer Preparation
+
+Binary buffers can be statically prepared for a given count number elements. Thise 

--- a/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/README.md
+++ b/src/Intermediate/Rxmxnx.PInvoke.Buffers.Intermediate/README.md
@@ -1,8 +1,8 @@
 ﻿`Rxmxnx.PInvoke.Extensions` supports the use of two types of buffers: binary and non-binary. The maximum capacity of any
 buffer is limited to 2<sup>15</sup> elements. However, this maximum capacity may not always be allocatable at runtime.
 
-Internally, all reference types utilize buffers of type `Object`. Only value types (both managed and unmanaged) require
-the use of buffers specific to their type.
+Internally, all reference types utilize buffers of type `Object`. Only not unmanaged value types require
+the use of buffers specific to their type, the unmanaged ones uses stackalloc.
 
 ---
 
@@ -28,9 +28,11 @@ In a Native AOT runtime, binary buffer composition requires metadata preservatio
 Below is an example of the metadata preservation needed to compose a binary buffer with a capacity of 10 elements of any
 reference type Composite(2<sup>1</sup>, 2<sup>3</sup>, `Object`).
 
-**Notes**: 
-* 2<sup>3</sup> is Composite(2<sup>2</sup>, 2<sup>2</sup>, `Object`), 2<sup>2</sup> is Composite(2<sup>1</sup>, 2<sup>1</sup>, `Object`), 2<sup>1</sup> is
-Composite(2<sup>0</sup>, 2<sup>0</sup>, `Object`) and 2<sup>0</sup> is Atomic(`Object`).
+**Notes**:
+
+* 2<sup>3</sup> is Composite(2<sup>2</sup>, 2<sup>2</sup>, `Object`), 2<sup>2</sup> is Composite(2<sup>1</sup>, 2<sup>
+  1</sup>, `Object`), 2<sup>1</sup> is
+  Composite(2<sup>0</sup>, 2<sup>0</sup>, `Object`) and 2<sup>0</sup> is Atomic(`Object`).
 * Once a buffer is composed, it becomes available for use. This process is executed only once for each capacity.
 
 ```xml

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/CStringSequence.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/CStringSequence.cs
@@ -117,7 +117,11 @@ public sealed partial class CStringSequence : ICloneable, IEquatable<CStringSequ
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	[Browsable(false)]
 	public ref readonly Byte GetPinnableReference()
-		=> ref MemoryMarshal.GetReference(MemoryMarshal.AsBytes(this._value.AsSpan()));
+	{
+		ReadOnlySpan<Char> chars = this._value.AsSpan();
+		ReadOnlySpan<Byte> bytes = MemoryMarshal.AsBytes(chars);
+		return ref MemoryMarshal.GetReference(bytes);
+	}
 	/// <summary>
 	/// Returns a <see cref="CString"/> that represents the current sequence.
 	/// </summary>

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/CStringSequence/PrivateStatic.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/CStringSequence/PrivateStatic.cs
@@ -83,8 +83,8 @@ public unsafe partial class CStringSequence
 	private static void CopyText(Span<Char> charSpan, CStringSpanState state)
 	{
 		Int32 position = 0;
-		ReadOnlySpan<CString?> values =
-			MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef<CString?>(state.Ptr), state.Length);
+		ref CString? refCStr = ref Unsafe.AsRef<CString?>(state.Ptr);
+		ReadOnlySpan<CString?> values = MemoryMarshal.CreateReadOnlySpan(ref refCStr, state.Length);
 		Span<Byte> byteSpan = MemoryMarshal.AsBytes(charSpan);
 		foreach (CString? value in values)
 		{

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/Internal/DecodedRune.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/Internal/DecodedRune.cs
@@ -143,7 +143,8 @@ internal readonly struct DecodedRune : IWrapper<Rune>, IEquatable<DecodedRune>
 	/// <param name="source">Source span from which the raw value will be copied.</param>
 	private static void CopyRawValue(ref Int32 integerValue, ReadOnlySpan<Byte> source)
 	{
-		Span<Byte> bytes = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref integerValue, 1));
+		Span<Int32> integers = MemoryMarshal.CreateSpan(ref integerValue, 1);
+		Span<Byte> bytes = MemoryMarshal.AsBytes(integers);
 		source.CopyTo(bytes);
 	}
 

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md
@@ -11,6 +11,8 @@ There are three types of `CString`:
    the developer have to ensure that the memory address holding the UTF-8/ASCII units remains valid for the
    lifetime of the `CString` instance.
 
+---
+
 ## CString Initialization
 
 The `CString` class offers various constructors and operators for creating `CString` instances:

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md
@@ -186,6 +186,8 @@ property is set to `false`; otherwise, it is set to `true`.
 **Note:** This method is considered *unsafe* because the pinning of the memory block pointed to by the resulting
 instance must be done manually.
 
+---
+
 ## CString Sequences
 
 `Rxmxnx.PInvoke.Extensions` natively supports the creation of null-terminated UTF-8/ASCII sequences to optimize the use

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md
@@ -22,13 +22,13 @@ Byte[] utf8Data = [ (Byte)'H', (Byte)'e', (Byte)'l', (Byte)'l', (Byte)'o', (Byte
 Byte[] utf8Data2 = utf8Data[..^1];
 CString cstring = (CString)utf8Data;
 
-Console.WriteLine(cstring); // Output: "Hello"
-Console.WriteLine(cstring.IsNullTerminated); // Output: True
+Console.WriteLine(cstring);                     // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated);    // Output: True
 
 cstring = utf8Data[..^1];
 
-Console.WriteLine(cstring); // Output: "Hello"
-Console.WriteLine(cstring.IsNullTerminated); // Output: False
+Console.WriteLine(cstring);                     // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated);    // Output: False
 ```
 
 This operator converts a `Byte[]` containing UTF-8/ASCII units into a `CString` instance. If
@@ -41,8 +41,8 @@ the last element of the array is a null character (`0x0`), it is excluded from t
 String text = new("Hello".AsSpan());
 CString cstring = (CString)text;
 
-Console.WriteLine(cstring); // Output: "Hello"
-Console.WriteLine(cstring.IsNullTerminated); // Output: True
+Console.WriteLine(cstring);                     // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated);    // Output: True
 ```
 
 This operator encodes a UTF-16 string into UTF-8, creating a managed buffer to store the
@@ -56,8 +56,8 @@ resulting bytes. It always reserves space for a null terminator, ensuring the `I
 ```csharp
 CString cstring = new(()=> "Hello"u8);
 
-Console.WriteLine(cstring); // Output: "Hello"
-Console.WriteLine(cstring.IsNullTerminated); // Output: True
+Console.WriteLine(cstring);                     // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated);    // Output: True
 ```
 
 This constructor enables the creation of `CString` instances
@@ -73,13 +73,13 @@ remains fixed.
 ReadOnlySpan<Byte> utf8Data = [ (Byte)'H', (Byte)'e', (Byte)'l', (Byte)'l', (Byte)'o', (Byte)'\0', ];
 CString cstring = new(utf8Data);
 
-Console.WriteLine(cstring); // Output: "Hello"
-Console.WriteLine(cstring.IsNullTerminated); // Output: True
+Console.WriteLine(cstring);                     // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated);    // Output: True
 
 cstring = new(utf8Data[..^1]);
 
-Console.WriteLine(cstring); // Output: "Hello"
-Console.WriteLine(cstring.IsNullTerminated); // Output: True
+Console.WriteLine(cstring);                     // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated);    // Output: True
 ```
 
 This constructor creates a `CString` instance by copying the content of a
@@ -92,13 +92,13 @@ buffer, and the `IsNullTerminated` property is set to `true`.
 ReadOnlySpan<Byte> utf8Data = [ (Byte)'H', (Byte)'e', (Byte)'l', (Byte)'l', (Byte)'o', (Byte)'\0', ];
 CString cstring = CString.Create(utf8Data);
 
-Console.WriteLine(cstring); // Output: "Hello\0"
-Console.WriteLine(cstring.IsNullTerminated); // Output: False
+Console.WriteLine(cstring);                     // Output: "Hello\0"
+Console.WriteLine(cstring.IsNullTerminated);    // Output: False
 
 cstring = CString.Create(utf8Data[..^1]);
 
-Console.WriteLine(cstring); // Output: "Hello"
-Console.WriteLine(cstring.IsNullTerminated); // Output: False
+Console.WriteLine(cstring);                     // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated);    // Output: False
 ```
 
 This method creates a `CString` instance by copying the content of a
@@ -134,16 +134,16 @@ CString cstring = CString.Create(new BytesSlice() {
    Start = 0,
 });
 
-Console.WriteLine(cstring); // Output: "Hello"
-Console.WriteLine(cstring.IsNullTerminated); // Output: True
+Console.WriteLine(cstring);                     // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated);    // Output: True
 
 cstring = CString.Create(new BytesSlice() {
    Bytes = utf8Data,
    Start = 2,
 });
 
-Console.WriteLine(cstring); // Output: "llo"
-Console.WriteLine(cstring.IsNullTerminated); // Output: True
+Console.WriteLine(cstring);                     // Output: "llo"
+Console.WriteLine(cstring.IsNullTerminated);    // Output: True
 
 cstring = CString.Create(new BytesSlice() {
    Bytes = utf8Data,
@@ -151,8 +151,8 @@ cstring = CString.Create(new BytesSlice() {
    End = 4,
 });
 
-Console.WriteLine(cstring); // Output: "Hell"
-Console.WriteLine(cstring.IsNullTerminated); // Output: False
+Console.WriteLine(cstring);                     // Output: "Hell"
+Console.WriteLine(cstring.IsNullTerminated);    // Output: False
 ```
 
 This method allows creating a `CString` instance using an object of type
@@ -163,16 +163,16 @@ This method allows creating a `CString` instance using an object of type
 ```csharp
 const Int32 length = 6;
 Byte* utf8Data = stackalloc Byte[length] { (Byte)'H', (Byte)'e', (Byte)'l', (Byte)'l', (Byte)'o', (Byte)'\0', };
-IntPtr ptr = (IntPtr)utf8Data; // Get stack pointer (safe).
+IntPtr ptr = (IntPtr)utf8Data;  // Get stack pointer (safe).
 CString? cstring = CString.CreateUnsafe(ptr, length, false);
 
-Console.WriteLine(cstring); // Output: "Hello"
-Console.WriteLine(cstring.IsNullTerminated); // Output: True
+Console.WriteLine(cstring);                     // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated);    // Output: True
 
 cstring = CString.CreateUnsafe(ptr, length, true);
 
-Console.WriteLine(cstring); // Output: "Hello\0"
-Console.WriteLine(cstring.IsNullTerminated); // Output: False
+Console.WriteLine(cstring);                     // Output: "Hello\0"
+Console.WriteLine(cstring.IsNullTerminated);    // Output: False
 
 cstring = null; // Discard unsafe instance
 ```
@@ -190,7 +190,7 @@ instance must be done manually.
 of managed buffers via the `CStringSequence` class.
 
 ```csharp
-const String val = "效汬o潗汲d"; // Hardcoded UTF-8: "Hello\0World\0"
+const String val = "效汬o潗汲d";    // Hardcoded UTF-8: "Hello\0World\0"
 CStringSequence seq0 = new("Hello", "World");
 CStringSequence seq1 = new("Hello"u8, "World"u8);
 CStringSequence seq2 = new(Encoding.UTF8.GetBytes("Hello"), Encoding.UTF8.GetBytes("World"));
@@ -198,22 +198,22 @@ CStringSequence seq3 = new(new CString(() => "Hello"u8), new CString(() => "Worl
 CStringSequence seq4 = CStringSequence.Parse(val);
 CStringSequence seq5 = CStringSequence.Create(val);
 
-Console.WriteLine(seq0.Count); // Output: 2
-Console.WriteLine(seq4.Count); // Output: 2
-Console.WriteLine(seq5.Count); // Output: 2
+Console.WriteLine(seq0.Count);  // Output: 2
+Console.WriteLine(seq4.Count);  // Output: 2
+Console.WriteLine(seq5.Count);  // Output: 2
 
-Console.WriteLine(seq0.ToString() == seq1.ToString()); // Output: True
-Console.WriteLine(seq0.ToString() == seq2.ToString()); // Output: True
-Console.WriteLine(seq0.ToString() == seq3.ToString()); // Output: True
-Console.WriteLine(seq0.ToString() == seq4.ToString()); // Output: True
-Console.WriteLine(seq0.ToString() == seq5.ToString()); // Output: True
+Console.WriteLine(seq0.ToString() == seq1.ToString());  // Output: True
+Console.WriteLine(seq0.ToString() == seq2.ToString());  // Output: True
+Console.WriteLine(seq0.ToString() == seq3.ToString());  // Output: True
+Console.WriteLine(seq0.ToString() == seq4.ToString());  // Output: True
+Console.WriteLine(seq0.ToString() == seq5.ToString());  // Output: True
 
-Console.WriteLine(Object.ReferenceEquals(val, seq0.ToString())); // Output: False
-Console.WriteLine(Object.ReferenceEquals(val, seq1.ToString())); // Output: False
-Console.WriteLine(Object.ReferenceEquals(val, seq2.ToString())); // Output: False
-Console.WriteLine(Object.ReferenceEquals(val, seq3.ToString())); // Output: False
-Console.WriteLine(Object.ReferenceEquals(val, seq4.ToString())); // Output: True
-Console.WriteLine(Object.ReferenceEquals(val, seq5.ToString())); // Output: False
+Console.WriteLine(Object.ReferenceEquals(val, seq0.ToString()));    // Output: False
+Console.WriteLine(Object.ReferenceEquals(val, seq1.ToString()));    // Output: False
+Console.WriteLine(Object.ReferenceEquals(val, seq2.ToString()));    // Output: False
+Console.WriteLine(Object.ReferenceEquals(val, seq3.ToString()));    // Output: False
+Console.WriteLine(Object.ReferenceEquals(val, seq4.ToString()));    // Output: True
+Console.WriteLine(Object.ReferenceEquals(val, seq5.ToString()));    // Output: False
 ```
 
 `CStringSequence` instances can be created from sequences of `String`, `CString`, or up to 8 `ReadOnlySpan<Byte>`

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md
@@ -5,7 +5,7 @@ There are three types of `CString`:
 
 1. **Managed Buffer-Based**: This type is based on a managed buffer, which can be either a `String` instance or a
    `Byte[]` array containing UTF-8/ASCII units.
-2. **Delegate-Based**: This type relies on a delegate that returns a `Span<byte>`. The delegate can represent a UTF-8 or
+2. **Delegate-Based**: This type relies on a delegate that returns a `Span<Byte>`. The delegate can represent a UTF-8 or
    ASCII literal, or an arbitrary function, with or without a state object.
 3. **Unmanaged Pointer-Based**: This type is based on an unmanaged pointer and a specified length. When use this type,
    the developer have to ensure that the memory address holding the UTF-8/ASCII units remains valid for the

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md
@@ -1,0 +1,225 @@
+﻿`Rxmxnx.PInvoke.Extensions` supports UTF-8/ASCII text handling through the `CString` class, inspired by
+C-style strings. These strings provide a simple and safe way to access UTF-8/ASCII units, regardless of their nature.
+
+There are three types of `CString`:
+
+1. **Managed Buffer-Based**: This type is based on a managed buffer, which can be either a `String` instance or a
+   `Byte[]` array containing UTF-8/ASCII units.
+2. **Delegate-Based**: This type relies on a delegate that returns a `Span<byte>`. The delegate can represent a UTF-8 or
+   ASCII literal, or an arbitrary function, with or without a state object.
+3. **Unmanaged Pointer-Based**: This type is based on an unmanaged pointer and a specified length. When use this type,
+   the developer have to ensure that the memory address holding the UTF-8/ASCII units remains valid for the
+   lifetime of the `CString` instance.
+
+## CString Initialization
+
+The `CString` class offers various constructors and operators for creating `CString` instances:
+
+### Implicit operator
+
+```csharp
+Byte[] utf8Data = [ (Byte)'H', (Byte)'e', (Byte)'l', (Byte)'l', (Byte)'o', (Byte)'\0', ];
+Byte[] utf8Data2 = utf8Data[..^1];
+CString cstring = (CString)utf8Data;
+
+Console.WriteLine(cstring); // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated); // Output: True
+
+cstring = utf8Data[..^1];
+
+Console.WriteLine(cstring); // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated); // Output: False
+```
+
+This operator converts a `Byte[]` containing UTF-8/ASCII units into a `CString` instance. If
+the last element of the array is a null character (`0x0`), it is excluded from the length count, and the
+`IsNullTerminated` property is set to `true`.
+
+### Explicit operator
+
+```csharp
+String text = new("Hello".AsSpan());
+CString cstring = (CString)text;
+
+Console.WriteLine(cstring); // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated); // Output: True
+```
+
+This operator encodes a UTF-16 string into UTF-8, creating a managed buffer to store the
+resulting bytes. It always reserves space for a null terminator, ensuring the `IsNullTerminated` property is always
+`true`.
+
+**Note:** This operator is considered *inefficient* when used with string literals.
+
+### Literal constructor
+
+```csharp
+CString cstring = new(()=> "Hello"u8);
+
+Console.WriteLine(cstring); // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated); // Output: True
+```
+
+This constructor enables the creation of `CString` instances
+using [UTF-8/ASCII literals](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-11.0/utf8-string-literals).
+
+**Note:** This constructor is considered **primary** because these literals are constants, ensuring their memory
+location
+remains fixed.
+
+### Span constructor
+
+```csharp
+ReadOnlySpan<Byte> utf8Data = [ (Byte)'H', (Byte)'e', (Byte)'l', (Byte)'l', (Byte)'o', (Byte)'\0', ];
+CString cstring = new(utf8Data);
+
+Console.WriteLine(cstring); // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated); // Output: True
+
+cstring = new(utf8Data[..^1]);
+
+Console.WriteLine(cstring); // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated); // Output: True
+```
+
+This constructor creates a `CString` instance by copying the content of a
+`ReadOnlySpan<Byte>` containing UTF-8/ASCII units into a managed buffer. It always appends a null character to the
+buffer, and the `IsNullTerminated` property is set to `true`.
+
+### Creation with span
+
+```csharp
+ReadOnlySpan<Byte> utf8Data = [ (Byte)'H', (Byte)'e', (Byte)'l', (Byte)'l', (Byte)'o', (Byte)'\0', ];
+CString cstring = CString.Create(utf8Data);
+
+Console.WriteLine(cstring); // Output: "Hello\0"
+Console.WriteLine(cstring.IsNullTerminated); // Output: False
+
+cstring = CString.Create(utf8Data[..^1]);
+
+Console.WriteLine(cstring); // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated); // Output: False
+```
+
+This method creates a `CString` instance by copying the content of a
+`ReadOnlySpan<Byte>` into a managed buffer without verifying the presence of a null terminator. The
+`IsNullTerminated` property is always set to `false`.
+
+### Creation with state
+
+```csharp
+private readonly struct BytesSlice : IUtf8FunctionState<BytesSlice>
+{
+   public Byte[] Bytes { get; init; }
+   public Int32 Start { get; init; }
+   public Int32? End { get; init; }
+   
+   public Boolean IsNullTerminated => (!this.End.HasValue || this.End == this.Bytes.Length) && this.Bytes.Length > 0 && this.Bytes[^1] == 0x0;
+   
+   public static Int32 GetLength(in BytesSlice state) {
+      Int32 length = state.End ?? state.Bytes.Length;
+      if (state.IsNullTerminated)
+         length--;
+      return length - state.Start;
+   }
+     
+   public static ReadOnlySpan<Byte> GetSpan(BytesSlice state) {
+      return state.Bytes.AsSpan().Slice(state.Start, GetLength(state));
+   }
+}
+...
+Byte[] utf8Data = [ (Byte)'H', (Byte)'e', (Byte)'l', (Byte)'l', (Byte)'o', (Byte)'\0', ]; 
+CString cstring = CString.Create(new BytesSlice() {
+   Bytes = utf8Data,
+   Start = 0,
+});
+
+Console.WriteLine(cstring); // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated); // Output: True
+
+cstring = CString.Create(new BytesSlice() {
+   Bytes = utf8Data,
+   Start = 2,
+});
+
+Console.WriteLine(cstring); // Output: "llo"
+Console.WriteLine(cstring.IsNullTerminated); // Output: True
+
+cstring = CString.Create(new BytesSlice() {
+   Bytes = utf8Data,
+   Start = 0,
+   End = 4,
+});
+
+Console.WriteLine(cstring); // Output: "Hell"
+Console.WriteLine(cstring.IsNullTerminated); // Output: False
+```
+
+This method allows creating a `CString` instance using an object of type
+`IUtf8FunctionState<TState>`, which provides UTF-8/ASCII units via a function.
+
+### Creation with pointer
+
+```csharp
+const Int32 length = 6;
+Byte* utf8Data = stackalloc Byte[length] { (Byte)'H', (Byte)'e', (Byte)'l', (Byte)'l', (Byte)'o', (Byte)'\0', };
+IntPtr ptr = (IntPtr)utf8Data; // Get stack pointer (safe).
+CString? cstring = CString.CreateUnsafe(ptr, length, false);
+
+Console.WriteLine(cstring); // Output: "Hello"
+Console.WriteLine(cstring.IsNullTerminated); // Output: True
+
+cstring = CString.CreateUnsafe(ptr, length, true);
+
+Console.WriteLine(cstring); // Output: "Hello\0"
+Console.WriteLine(cstring.IsNullTerminated); // Output: False
+
+cstring = null; // Discard unsafe instance
+```
+
+This method creates a `CString` instance that points to an unmanaged
+memory block containing UTF-8/ASCII units of a specified length. If the full length is used, the `IsNullTerminated`
+property is set to `false`; otherwise, it is set to `true`.
+
+**Note:** This method is considered *unsafe* because the pinning of the memory block pointed to* by the resulting
+instance *must be done manually.
+
+## CString Sequences
+
+`Rxmxnx.PInvoke.Extensions` natively supports the creation of null-terminated UTF-8/ASCII sequences to optimize the use
+of managed buffers via the `CStringSequence` class.
+
+```csharp
+const String val = "效汬o潗汲d"; // Hardcoded UTF-8: "Hello\0World\0"
+CStringSequence seq0 = new("Hello", "World");
+CStringSequence seq1 = new("Hello"u8, "World"u8);
+CStringSequence seq2 = new(Encoding.UTF8.GetBytes("Hello"), Encoding.UTF8.GetBytes("World"));
+CStringSequence seq3 = new(new CString(() => "Hello"u8), new CString(() => "World"u8));
+CStringSequence seq4 = CStringSequence.Parse(val);
+CStringSequence seq5 = CStringSequence.Create(val);
+
+Console.WriteLine(seq0.Count); // Output: 2
+Console.WriteLine(seq4.Count); // Output: 2
+Console.WriteLine(seq5.Count); // Output: 2
+
+Console.WriteLine(seq0.ToString() == seq1.ToString()); // Output: True
+Console.WriteLine(seq0.ToString() == seq2.ToString()); // Output: True
+Console.WriteLine(seq0.ToString() == seq3.ToString()); // Output: True
+Console.WriteLine(seq0.ToString() == seq4.ToString()); // Output: True
+Console.WriteLine(seq0.ToString() == seq5.ToString()); // Output: True
+
+Console.WriteLine(Object.ReferenceEquals(val, seq0.ToString())); // Output: False
+Console.WriteLine(Object.ReferenceEquals(val, seq1.ToString())); // Output: False
+Console.WriteLine(Object.ReferenceEquals(val, seq2.ToString())); // Output: False
+Console.WriteLine(Object.ReferenceEquals(val, seq3.ToString())); // Output: False
+Console.WriteLine(Object.ReferenceEquals(val, seq4.ToString())); // Output: True
+Console.WriteLine(Object.ReferenceEquals(val, seq5.ToString())); // Output: False
+```
+
+`CStringSequence` instances can be created from sequences of `String`, `CString`, or up to 8 `ReadOnlySpan<Byte>`
+elements. In all cases, a buffer is created to ensure that each element in the sequence is stored consecutively,
+separated by a null character. The buffer itself is also null-terminated, ensuring compatibility with interop scenarios.
+
+The `Parse(String)` method is the only one that might avoid creating a new buffer if the input `String` meets the
+criteria to serve directly as the buffer for a `CStringSequence` instance. This is particularly useful when constant
+UTF-8/ASCII sequences (hardcoded) are required.

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/README.md
@@ -156,7 +156,7 @@ Console.WriteLine(cstring.IsNullTerminated); // Output: False
 ```
 
 This method allows creating a `CString` instance using an object of type
-`IUtf8FunctionState<TState>`, which provides UTF-8/ASCII units via a function.
+`IUtf8FunctionState<TState>`, which provides UTF-8/ASCII units using a delegate.
 
 ### Creation with pointer
 
@@ -181,8 +181,8 @@ This method creates a `CString` instance that points to an unmanaged
 memory block containing UTF-8/ASCII units of a specified length. If the full length is used, the `IsNullTerminated`
 property is set to `false`; otherwise, it is set to `true`.
 
-**Note:** This method is considered *unsafe* because the pinning of the memory block pointed to* by the resulting
-instance *must be done manually.
+**Note:** This method is considered *unsafe* because the pinning of the memory block pointed to by the resulting
+instance must be done manually.
 
 ## CString Sequences
 

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/FixedMemoryList.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/FixedMemoryList.cs
@@ -62,11 +62,10 @@ public readonly ref struct FixedMemoryList
 	/// </returns>
 	public IFixedMemory[] ToArray()
 	{
-		if (this._values.Count <= 0) return [];
-
 		IFixedMemory[] result = new IFixedMemory[this._values.Count];
-		ref ReadOnlyFixedMemory refI = ref Unsafe.As<IFixedMemory, ReadOnlyFixedMemory>(ref result[0]);
-		Span<ReadOnlyFixedMemory> span = MemoryMarshal.CreateSpan(ref refI, result.Length);
+		ref IFixedMemory refI = ref MemoryMarshal.GetReference(result.AsSpan());
+		ref ReadOnlyFixedMemory refRo = ref Unsafe.As<IFixedMemory, ReadOnlyFixedMemory>(ref refI);
+		Span<ReadOnlyFixedMemory> span = MemoryMarshal.CreateSpan(ref refRo, result.Length);
 		this._values.AsSpan().CopyTo(span);
 		return result;
 	}

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedContext.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedContext.cs
@@ -15,7 +15,7 @@ internal sealed unsafe partial class FixedContext<T> : FixedMemory, IFixedContex
 	/// <summary>
 	/// An empty instance of <see cref="IFixedContext{T}.IDisposable"/>.
 	/// </summary>
-	public static readonly IFixedContext<T>.IDisposable EmptyDisposable = Disposable.Empty;
+	public static readonly IFixedContext<T>.IDisposable EmptyDisposable = Disposable.Default;
 
 	/// <summary>
 	/// Gets the number of items of type <typeparamref name="T"/> in the memory block.

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedContext.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedContext.cs
@@ -12,6 +12,10 @@ internal sealed unsafe partial class FixedContext<T> : FixedMemory, IFixedContex
 	/// An empty instance of <see cref="FixedContext{T}"/>.
 	/// </summary>
 	public static readonly FixedContext<T> Empty = new();
+	/// <summary>
+	/// An empty instance of <see cref="IFixedContext{T}.IDisposable"/>.
+	/// </summary>
+	public static readonly IFixedContext<T>.IDisposable EmptyDisposable = Disposable.Empty;
 
 	/// <summary>
 	/// Gets the number of items of type <typeparamref name="T"/> in the memory block.

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedContext/Disposable.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedContext/Disposable.cs
@@ -20,7 +20,7 @@ internal partial class FixedContext<T> : IConvertibleDisposable<IFixedContext<T>
 		/// <summary>
 		/// An empty instance of <see cref="FixedContext{T}.Disposable"/>.
 		/// </summary>
-		public static readonly Disposable Empty = new(FixedContext<T>.Empty, default);
+		public new static readonly Disposable Empty = new(FixedContext<T>.Empty, default);
 
 		/// <inheritdoc/>
 		public Disposable(FixedContext<T> fixedPointer, IDisposable? disposable) : base(fixedPointer, disposable) { }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedContext/Disposable.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedContext/Disposable.cs
@@ -20,7 +20,7 @@ internal partial class FixedContext<T> : IConvertibleDisposable<IFixedContext<T>
 		/// <summary>
 		/// An empty instance of <see cref="FixedContext{T}.Disposable"/>.
 		/// </summary>
-		public new static readonly Disposable Empty = new(FixedContext<T>.Empty, default);
+		public static readonly Disposable Default = new(FixedContext<T>.Empty, default);
 
 		/// <inheritdoc/>
 		public Disposable(FixedContext<T> fixedPointer, IDisposable? disposable) : base(fixedPointer, disposable) { }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedContext/Disposable.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedContext/Disposable.cs
@@ -17,6 +17,11 @@ internal partial class FixedContext<T> : IConvertibleDisposable<IFixedContext<T>
 	/// </summary>
 	private sealed class Disposable : Disposable<FixedContext<T>>, IFixedContext<T>.IDisposable
 	{
+		/// <summary>
+		/// An empty instance of <see cref="FixedContext{T}.Disposable"/>.
+		/// </summary>
+		public static readonly Disposable Empty = new(FixedContext<T>.Empty, default);
+
 		/// <inheritdoc/>
 		public Disposable(FixedContext<T> fixedPointer, IDisposable? disposable) : base(fixedPointer, disposable) { }
 

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedPointer.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedPointer.cs
@@ -250,7 +250,11 @@ internal abstract unsafe partial class FixedPointer : IFixedPointer
 	/// <summary>
 	/// Invalidates current context.
 	/// </summary>
-	public virtual void Unload() => this._isValid.Value = false;
+	public virtual void Unload()
+	{
+		if (this._ptr == default && this._binaryLength == 0) return;
+		this._isValid.Value = false;
+	}
 
 	/// <summary>
 	/// Validates any operation over the fixed memory block.

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedRentedContext.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedRentedContext.cs
@@ -1,0 +1,112 @@
+namespace Rxmxnx.PInvoke.Internal;
+
+/// <summary>
+/// Contains a rented fixed array instance
+/// </summary>
+internal sealed class FixedRentedContext<T> : IFixedContext<T>.IDisposable
+{
+	/// <summary>
+	/// Array pool.
+	/// </summary>
+	private readonly ArrayPool<T> _arrayPool;
+	/// <summary>
+	/// Indicates whether the contents of the buffer should be cleared before reuse.
+	/// </summary>
+	private readonly Boolean _clearArray;
+	/// <summary>
+	/// Internal fixed context.
+	/// </summary>
+	private readonly FixedContext<T> _ctx;
+	/// <summary>
+	/// <see cref="MemoryHandle"/> from array.
+	/// </summary>
+	private MemoryHandle _handle;
+
+	/// <summary>
+	/// Rented array;
+	/// </summary>
+	public T[] Array { get; }
+
+	/// <summary>
+	/// Private constructor.
+	/// </summary>
+	/// <param name="arrayPool">A <see cref="ArrayPool{T}"/> instance.</param>
+	/// <param name="length">Required length.</param>
+	/// <param name="clearArray">Indicates whether the contents of the buffer should be cleared before reuse.</param>
+	public unsafe FixedRentedContext(ArrayPool<T> arrayPool, Int32 length, Boolean clearArray)
+	{
+		this._arrayPool = arrayPool;
+		this.Array = arrayPool.Rent(length);
+		this._clearArray = clearArray;
+		this._handle = this.Array.AsMemory().Pin();
+		this._ctx = new(this._handle.Pointer, length);
+	}
+
+	[ExcludeFromCodeCoverage]
+	IFixedContext<TDestination> IFixedContext<T>.Transformation<TDestination>(out IFixedMemory residual)
+		=> this.GetContext().Transformation<TDestination>(out residual);
+	[ExcludeFromCodeCoverage]
+	IFixedContext<TDestination> IFixedContext<T>.Transformation<TDestination>(out IReadOnlyFixedMemory residual)
+		=> this.GetContext().Transformation<TDestination>(out residual);
+	[ExcludeFromCodeCoverage]
+	IReadOnlyFixedContext<TDestination> IReadOnlyFixedContext<T>.
+		Transformation<TDestination>(out IReadOnlyFixedMemory residual)
+		=> this.GetContext().Transformation<TDestination>(out residual);
+	[ExcludeFromCodeCoverage]
+	IntPtr IFixedPointer.Pointer => this.GetContext().Pointer;
+	[ExcludeFromCodeCoverage]
+	Boolean IReadOnlyFixedMemory.IsNullOrEmpty => this.GetContext().IsNullOrEmpty;
+	[ExcludeFromCodeCoverage]
+	Span<Byte> IFixedMemory.Bytes => this.GetContext().Bytes;
+	[ExcludeFromCodeCoverage]
+	Span<Object> IFixedMemory.Objects => this.GetContext().Objects;
+	[ExcludeFromCodeCoverage]
+	ReadOnlySpan<Byte> IReadOnlyFixedMemory.Bytes => this.GetReadOnlyContext().Bytes;
+	[ExcludeFromCodeCoverage]
+	ReadOnlySpan<Object> IReadOnlyFixedMemory.Objects => this.GetReadOnlyContext().Objects;
+	[ExcludeFromCodeCoverage]
+	IReadOnlyFixedContext<Byte> IReadOnlyFixedMemory.AsBinaryContext() => this.GetReadOnlyContext().AsBinaryContext();
+	[ExcludeFromCodeCoverage]
+	IFixedContext<Object> IFixedMemory.AsObjectContext() => this.GetContext().AsObjectContext();
+	[ExcludeFromCodeCoverage]
+	IFixedContext<Byte> IFixedMemory.AsBinaryContext() => this.GetContext().AsBinaryContext();
+	[ExcludeFromCodeCoverage]
+	IReadOnlyFixedContext<Object> IReadOnlyFixedMemory.AsObjectContext() => this.GetReadOnlyContext().AsObjectContext();
+	[ExcludeFromCodeCoverage]
+	ReadOnlySpan<T> IReadOnlyFixedMemory<T>.Values => this.GetContext().Values;
+	[ExcludeFromCodeCoverage]
+	Span<T> IFixedMemory<T>.Values => this.GetContext().Values;
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		this.Release();
+		GC.SuppressFinalize(this);
+	}
+
+	[ExcludeFromCodeCoverage]
+	~FixedRentedContext() => this.Release();
+
+	/// <summary>
+	/// Release all resources.
+	/// </summary>
+	private void Release()
+	{
+		this._ctx.Unload();
+		this._handle.Dispose();
+		this._arrayPool.Return(this.Array, this._clearArray);
+	}
+
+	/// <summary>
+	/// Fixed context.
+	/// </summary>
+	[ExcludeFromCodeCoverage]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private IFixedContext<T> GetContext() => this._ctx;
+	/// <summary>
+	/// Read-only fixed context.
+	/// </summary>
+	[ExcludeFromCodeCoverage]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private IFixedContext<T> GetReadOnlyContext() => this._ctx;
+}

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedRentedContext.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedRentedContext.cs
@@ -33,6 +33,7 @@ internal sealed class FixedRentedContext<T> : IFixedContext<T>.IDisposable
 	/// <param name="arrayPool">A <see cref="ArrayPool{T}"/> instance.</param>
 	/// <param name="length">Required length.</param>
 	/// <param name="clearArray">Indicates whether the contents of the buffer should be cleared before reuse.</param>
+	[SuppressMessage(SuppressMessageConstants.CSharpSquid, SuppressMessageConstants.CheckIdS6640)]
 	public unsafe FixedRentedContext(ArrayPool<T> arrayPool, Int32 length, Boolean clearArray)
 	{
 		this._arrayPool = arrayPool;

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/ArabicMessageResource.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/ArabicMessageResource.cs
@@ -58,4 +58,6 @@ internal sealed class ArabicMessageResource : IMessageResource
 		=> $"{itemType} هو نوع مرجعي لكن {arrayType} هو نوع غير مُدار.";
 	String IMessageResource.UnmanagedTypeButContainsReferences(Type itemType, Type arrayType)
 		=> $"{itemType} هو نوع غير مُدار لكن {arrayType} يحتوي على مراجع.";
+	String IMessageResource.MissingBufferMetadataException(Type itemType, UInt16 size)
+		=> $"تعذّر إنشاء مخزن مؤقت لـ {itemType} يضم {size} عناصر.";
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/ChineseMessageResource.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/ChineseMessageResource.cs
@@ -55,4 +55,6 @@ internal sealed class ChineseMessageResource : IMessageResource
 		=> $"{itemType} 是引用类型，但 {arrayType} 是非托管类型。";
 	String IMessageResource.UnmanagedTypeButContainsReferences(Type itemType, Type arrayType)
 		=> $"{itemType} 是非托管类型，但 {arrayType} 包含引用。";
+	String IMessageResource.MissingBufferMetadataException(Type itemType, UInt16 size)
+		=> $"无法为 {itemType} 创建包含 {size} 项的缓冲区。";
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/DefaultMessageResource.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/DefaultMessageResource.cs
@@ -60,4 +60,6 @@ internal sealed class DefaultMessageResource : IMessageResource
 		=> $"{itemType} is a reference type but {arrayType} is unmanaged type.";
 	String IMessageResource.UnmanagedTypeButContainsReferences(Type itemType, Type arrayType)
 		=> $"{itemType} is an unmanaged type but {arrayType} contains references.";
+	String IMessageResource.MissingBufferMetadataException(Type itemType, UInt16 size)
+		=> $"Unable to create buffer for {itemType} {size} items.";
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/FrenchMessageResource.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/FrenchMessageResource.cs
@@ -63,4 +63,6 @@ internal sealed class FrenchMessageResource : IMessageResource
 		=> $"{itemType} est un type de référence mais {arrayType} est un type non géré.";
 	String IMessageResource.UnmanagedTypeButContainsReferences(Type itemType, Type arrayType)
 		=> $"{itemType} est un type non géré mais {arrayType} contient des références.";
+	String IMessageResource.MissingBufferMetadataException(Type itemType, UInt16 size)
+		=> $"Impossible de créer un tampon pour {itemType} comportant {size} éléments.";
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/GermanMessageResource.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/GermanMessageResource.cs
@@ -62,4 +62,6 @@ internal sealed class GermanMessageResource : IMessageResource
 		=> $"{itemType} ist ein Referenztyp, aber {arrayType} ist ein nicht verwalteter Typ.";
 	String IMessageResource.UnmanagedTypeButContainsReferences(Type itemType, Type arrayType)
 		=> $"{itemType} ist ein nicht verwalteter Typ, aber {arrayType} enthält Verweise.";
+	String IMessageResource.MissingBufferMetadataException(Type itemType, UInt16 size)
+		=> $"Es ist nicht möglich, einen Puffer für {itemType} mit {size} Elementen zu erstellen.";
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/IMessageResource.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/IMessageResource.cs
@@ -135,4 +135,8 @@ internal partial interface IMessageResource
 	/// Message for unmanaged type item but containing array references exception.
 	/// </summary>
 	String UnmanagedTypeButContainsReferences(Type itemType, Type arrayType);
+	/// <summary>
+	/// Message for missing buffer metadata exception.
+	/// </summary>
+	String MissingBufferMetadataException(Type itemType, UInt16 size);
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/ItalianMessageResource.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/ItalianMessageResource.cs
@@ -63,4 +63,6 @@ internal sealed class ItalianMessageResource : IMessageResource
 		=> $"{itemType} è un tipo di riferimento ma {arrayType} è un tipo non gestito.";
 	String IMessageResource.UnmanagedTypeButContainsReferences(Type itemType, Type arrayType)
 		=> $"{itemType} è un tipo non gestito ma {arrayType} contiene riferimenti.";
+	String IMessageResource.MissingBufferMetadataException(Type itemType, UInt16 size)
+		=> $"Impossibile creare un buffer per {itemType} con {size} elementi.";
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/JapaneseMessageResource.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/JapaneseMessageResource.cs
@@ -57,4 +57,6 @@ internal sealed class JapaneseMessageResource : IMessageResource
 		=> $"{itemType} は参照型ですが、{arrayType} は非管理型です。";
 	String IMessageResource.UnmanagedTypeButContainsReferences(Type itemType, Type arrayType)
 		=> $"{itemType} は非管理型ですが、{arrayType} は参照を含んでいます。";
+	String IMessageResource.MissingBufferMetadataException(Type itemType, UInt16 size)
+		=> $"{itemType} の {size} アイテム用のバッファを作成できません。";
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/PortugueseMessageResource.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/PortugueseMessageResource.cs
@@ -62,4 +62,6 @@ internal sealed class PortugueseMessageResource : IMessageResource
 		=> $"{itemType} é um tipo de referência, mas {arrayType} é um tipo não gerenciado.";
 	String IMessageResource.UnmanagedTypeButContainsReferences(Type itemType, Type arrayType)
 		=> $"{itemType} é um tipo não gerenciado, mas {arrayType} contém referências.";
+	String IMessageResource.MissingBufferMetadataException(Type itemType, UInt16 size)
+		=> $"Não é possível criar um buffer para {itemType} com {size} itens.";
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/RussianMessageResource.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/RussianMessageResource.cs
@@ -62,4 +62,6 @@ internal sealed class RussianMessageResource : IMessageResource
 		=> $"{itemType} является ссылочным типом, но {arrayType} является неуправляемым типом.";
 	String IMessageResource.UnmanagedTypeButContainsReferences(Type itemType, Type arrayType)
 		=> $"{itemType} является неуправляемым типом, но {arrayType} содержит ссылки.";
+	String IMessageResource.MissingBufferMetadataException(Type itemType, UInt16 size)
+		=> $"Невозможно создать буфер для {itemType} с {size} элементами.";
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/SpanishMessageResource.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/Localization/SpanishMessageResource.cs
@@ -62,4 +62,6 @@ internal sealed class SpanishMessageResource : IMessageResource
 		=> $"{itemType} es un tipo de referencia pero {arrayType} es un tipo no administrado.";
 	String IMessageResource.UnmanagedTypeButContainsReferences(Type itemType, Type arrayType)
 		=> $"{itemType} es un tipo no administrado pero {arrayType} contiene referencias.";
+	String IMessageResource.MissingBufferMetadataException(Type itemType, UInt16 size)
+		=> $"No se puede crear un búfer para {itemType} con {size} elementos.";
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ReadOnlyFixedContext.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ReadOnlyFixedContext.cs
@@ -12,6 +12,10 @@ internal sealed unsafe partial class ReadOnlyFixedContext<T> : ReadOnlyFixedMemo
 	/// An empty instance of <see cref="ReadOnlyFixedContext{T}"/>.
 	/// </summary>
 	public static readonly ReadOnlyFixedContext<T> Empty = new();
+	/// <summary>
+	/// An empty instance of <see cref="IReadOnlyFixedContext{T}.IDisposable"/>.
+	/// </summary>
+	public static readonly IReadOnlyFixedContext<T>.IDisposable EmptyDisposable = Disposable.Empty;
 
 	/// <inheritdoc/>
 	public override Boolean IsUnmanaged => !RuntimeHelpers.IsReferenceOrContainsReferences<T>();

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ReadOnlyFixedContext.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ReadOnlyFixedContext.cs
@@ -15,7 +15,7 @@ internal sealed unsafe partial class ReadOnlyFixedContext<T> : ReadOnlyFixedMemo
 	/// <summary>
 	/// An empty instance of <see cref="IReadOnlyFixedContext{T}.IDisposable"/>.
 	/// </summary>
-	public static readonly IReadOnlyFixedContext<T>.IDisposable EmptyDisposable = Disposable.Empty;
+	public static readonly IReadOnlyFixedContext<T>.IDisposable EmptyDisposable = Disposable.Default;
 
 	/// <inheritdoc/>
 	public override Boolean IsUnmanaged => !RuntimeHelpers.IsReferenceOrContainsReferences<T>();

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ReadOnlyFixedContext/Disposable.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ReadOnlyFixedContext/Disposable.cs
@@ -21,7 +21,7 @@ internal partial class ReadOnlyFixedContext<T> : IConvertibleDisposable<IReadOnl
 		/// <summary>
 		/// An empty instance of <see cref="ReadOnlyFixedContext{T}.Disposable"/>.
 		/// </summary>
-		public new static readonly Disposable Empty = new(ReadOnlyFixedContext<T>.Empty, default);
+		public static readonly Disposable Default = new(ReadOnlyFixedContext<T>.Empty, default);
 
 		/// <inheritdoc/>
 		public Disposable(ReadOnlyFixedContext<T> fixedPointer, IDisposable? disposable) : base(

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ReadOnlyFixedContext/Disposable.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ReadOnlyFixedContext/Disposable.cs
@@ -21,7 +21,7 @@ internal partial class ReadOnlyFixedContext<T> : IConvertibleDisposable<IReadOnl
 		/// <summary>
 		/// An empty instance of <see cref="ReadOnlyFixedContext{T}.Disposable"/>.
 		/// </summary>
-		public static readonly Disposable Empty = new(ReadOnlyFixedContext<T>.Empty, default);
+		public new static readonly Disposable Empty = new(ReadOnlyFixedContext<T>.Empty, default);
 
 		/// <inheritdoc/>
 		public Disposable(ReadOnlyFixedContext<T> fixedPointer, IDisposable? disposable) : base(

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ReadOnlyFixedContext/Disposable.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ReadOnlyFixedContext/Disposable.cs
@@ -18,6 +18,11 @@ internal partial class ReadOnlyFixedContext<T> : IConvertibleDisposable<IReadOnl
 	/// </summary>
 	private sealed class Disposable : Disposable<ReadOnlyFixedContext<T>>, IReadOnlyFixedContext<T>.IDisposable
 	{
+		/// <summary>
+		/// An empty instance of <see cref="ReadOnlyFixedContext{T}.Disposable"/>.
+		/// </summary>
+		public static readonly Disposable Empty = new(ReadOnlyFixedContext<T>.Empty, default);
+
 		/// <inheritdoc/>
 		public Disposable(ReadOnlyFixedContext<T> fixedPointer, IDisposable? disposable) : base(
 			fixedPointer, disposable) { }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ValidationUtilities.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ValidationUtilities.cs
@@ -510,6 +510,21 @@ internal static unsafe class ValidationUtilities
 		if (!String.IsNullOrEmpty(message))
 			throw new InvalidOperationException(message);
 	}
+	/// <summary>
+	/// Throws an exception if buffer metadata is null.
+	/// </summary>
+	/// <param name="itemType">CLR item type.</param>
+	/// <param name="isNull">Indicates whether buffer metadata is null.</param>
+	/// <param name="size">Buffer size.</param>
+	/// <exception cref="InvalidOperationException">Throws an exception if buffer metadata is null.</exception>
+	[ExcludeFromCodeCoverage]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static void ThrowIfNullMetadata(Type itemType, UInt16 size, Boolean isNull)
+	{
+		if (!isNull) return;
+		IMessageResource resource = IMessageResource.GetInstance();
+		throw new InvalidOperationException(resource.MissingBufferMetadataException(itemType, size));
+	}
 #if BINARY_SPACES
 	/// <summary>
 	/// Throws an exception if buffer is not a space.

--- a/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/README.md
+++ b/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/README.md
@@ -1,0 +1,111 @@
+﻿The `Rxmxnx.PInvoke.Extensions` library provides various methods and extensions to simplify working with unmanaged
+pointers and managed memory handling.
+
+---
+
+## Managed Memory Handling
+
+The managed memory methods and extensions enable operations such as transformations and pinning. These methods are safe
+because, although they internally use the `Unsafe` class, they exclusively operate on GC-managed references. This
+ensures that the memory adheres to the .NET runtime safety guarantees.
+
+```csharp
+Span<Char> chars = "Hello world".AsSpan().ToArray();
+Span<Int32> values = chars.AsValues<Char, Int32>(out Span<Byte> bytes);
+
+Console.WriteLine(chars.ToString());    // Output: Hello world
+
+foreach(ref Int32 val in values)
+    val = val ^ 181;
+
+foreach(ref Byte val in bytes)
+    val = (Byte)(val ^ 5);
+
+Console.WriteLine(chars.ToString());    // Output: ýeÙlÚ ÂoÇlա
+
+foreach(ref Int32 val in values)
+    val = val ^ 181;
+
+foreach(ref Byte val in bytes)
+    val = (Byte)(val ^ 5);
+
+Console.WriteLine(chars.ToString());    // Output: Hello world
+```
+
+Additionally, by using `fixed` contexts, these methods allow managed memory to be accessed via pointers while
+guaranteeing that the memory remains fixed in place using the GC. This approach provides both safety and flexibility for
+scenarios requiring low-level memory access.
+
+```csharp
+Span<Byte> c8 = "Hello world"u8.ToArray();
+Int16[] c16 = new Int16[c8.Length];
+
+c8.WithSafeFixed(c16, (in IFixedContext<Byte> ctx, Int16[] state) => {
+    
+    GC.Collect();
+    GC.WaitForFullGCComplete();
+    
+    String text = Marshal.PtrToStringUTF8(ctx.Pointer);
+    
+    Console.WriteLine(text);    // Output: Hello world
+    
+    text.AsSpan().AsBytes().CopyTo(state.AsSpan().AsBytes());
+});
+
+using (IFixedContext<Int16>.IDisposable ctx = c16.AsMemory().GetFixedContext())
+    Console.WriteLine(Marshal.PtrToStringUni(ctx.Pointer)); // Output: Hello world
+```
+
+---
+
+## Unsafe Methods and Extensions
+
+Unsafe methods and extensions utilize unmanaged pointers. These methods are inherently unsafe because ensuring the
+validity of the memory address being pointed to must be handled manually.
+
+```csharp
+Int32 i = 10;
+ref Int32 refI = ref i;
+IntPtr u16Ptr = "Hello world".AsSpan().GetUnsafeIntPtr();
+IntPtr u8Ptr = "Hello world"u8.GetUnsafeIntPtr();
+IntPtr lPtr = stackalloc Int64[4]
+{
+    0x502e786e786d7852, // In UTF-8: Rxmxnx.P
+    0x452e656b6f766e49, // In UTF-8: Invoke.E
+    0x6e6f69736e657478, // In UTF-8: xtension
+    0x73,               // In UTF-8: s
+}.GetUnsafeIntPtr();
+IntPtr iPtr = refI.GetUnsafeIntPtr();
+
+GC.Collect();
+GC.WaitForFullGCComplete();
+i = 20;
+
+Console.WriteLine(Marshal.PtrToStringUni(u16Ptr));  // Output: Hello world
+Console.WriteLine(Marshal.PtrToStringUTF8(u8Ptr));  // Output: Hello world
+Console.WriteLine(Marshal.PtrToStringUTF8(lPtr));   // Output: Rxmxnx.PInvoke.Extensions
+Console.WriteLine(Marshal.ReadInt32(iPtr));         // Output: 20
+```
+
+These methods should only be used with constants, literals, or pointers to stack-allocated memory,
+but they can also be used in scenarios involving native memory (known to be fixed) or managed memory allocated on the
+heap, fixed explicitly using `fixed` or `GCHandle.Alloc`.
+
+```csharp
+Memory<Int32> values = new Int32[]
+{
+    0x650048,   // In UTF-16: He
+    0x6c006c,   // In UTF-16: ll
+    0x20006f,   // In UTF-16: o 
+    0x6f0057,   // In UTF-16: wo
+    0x6c0072,   // In UTF-16: rl
+    0x64        // In UTF-16: d
+};
+using MemoryHandle handle = values.Pin();
+
+GC.Collect();
+GC.WaitForFullGCComplete();
+
+IntPtr u16Ptr = values.Span.GetUnsafeIntPtr();
+Console.WriteLine(Marshal.PtrToStringUni(u16Ptr));  // Output: Hello world
+```

--- a/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/README.md
+++ b/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/README.md
@@ -13,7 +13,7 @@ ensures that the memory adheres to the .NET runtime safety guarantees.
 Span<Char> chars = "Hello world".AsSpan().ToArray();
 Span<Int32> values = chars.AsValues<Char, Int32>(out Span<Byte> bytes);
 
-Console.WriteLine(chars.ToString());    // Output: Hello world
+Console.WriteLine(chars.ToString());    // Output: "Hello world"
 
 foreach(ref Int32 val in values)
     val = val ^ 181;
@@ -21,7 +21,7 @@ foreach(ref Int32 val in values)
 foreach(ref Byte val in bytes)
     val = (Byte)(val ^ 5);
 
-Console.WriteLine(chars.ToString());    // Output: ýeÙlÚ ÂoÇlա
+Console.WriteLine(chars.ToString());    // Output: "ýeÙlÚ ÂoÇlա"
 
 foreach(ref Int32 val in values)
     val = val ^ 181;
@@ -29,7 +29,7 @@ foreach(ref Int32 val in values)
 foreach(ref Byte val in bytes)
     val = (Byte)(val ^ 5);
 
-Console.WriteLine(chars.ToString());    // Output: Hello world
+Console.WriteLine(chars.ToString());    // Output: "Hello world"
 ```
 
 Additionally, by using `fixed` contexts, these methods allow managed memory to be accessed via pointers while
@@ -47,13 +47,13 @@ c8.WithSafeFixed(c16, (in IFixedContext<Byte> ctx, Int16[] state) => {
     
     String text = Marshal.PtrToStringUTF8(ctx.Pointer);
     
-    Console.WriteLine(text);    // Output: Hello world
+    Console.WriteLine(text);    // Output: "Hello world"
     
     text.AsSpan().AsBytes().CopyTo(state.AsSpan().AsBytes());
 });
 
 using (IFixedContext<Int16>.IDisposable ctx = c16.AsMemory().GetFixedContext())
-    Console.WriteLine(Marshal.PtrToStringUni(ctx.Pointer)); // Output: Hello world
+    Console.WriteLine(Marshal.PtrToStringUni(ctx.Pointer)); // Output: "Hello world"
 ```
 
 ---
@@ -70,10 +70,10 @@ IntPtr u16Ptr = "Hello world".AsSpan().GetUnsafeIntPtr();
 IntPtr u8Ptr = "Hello world"u8.GetUnsafeIntPtr();
 IntPtr lPtr = stackalloc Int64[4]
 {
-    0x502e786e786d7852, // In UTF-8: Rxmxnx.P
-    0x452e656b6f766e49, // In UTF-8: Invoke.E
-    0x6e6f69736e657478, // In UTF-8: xtension
-    0x73,               // In UTF-8: s
+    0x502e786e786d7852, // Hardcoded UTF-8: "Rxmxnx.P"
+    0x452e656b6f766e49, // Hardcoded UTF-8: "Invoke.E"
+    0x6e6f69736e657478, // Hardcoded UTF-8: "xtension"
+    0x73,               // Hardcoded UTF-8: "s"
 }.GetUnsafeIntPtr();
 IntPtr iPtr = refI.GetUnsafeIntPtr();
 
@@ -81,9 +81,9 @@ GC.Collect();
 GC.WaitForFullGCComplete();
 i = 20;
 
-Console.WriteLine(Marshal.PtrToStringUni(u16Ptr));  // Output: Hello world
-Console.WriteLine(Marshal.PtrToStringUTF8(u8Ptr));  // Output: Hello world
-Console.WriteLine(Marshal.PtrToStringUTF8(lPtr));   // Output: Rxmxnx.PInvoke.Extensions
+Console.WriteLine(Marshal.PtrToStringUni(u16Ptr));  // Output: "Hello world"
+Console.WriteLine(Marshal.PtrToStringUTF8(u8Ptr));  // Output: "Hello world"
+Console.WriteLine(Marshal.PtrToStringUTF8(lPtr));   // Output: "Rxmxnx.PInvoke.Extensions"
 Console.WriteLine(Marshal.ReadInt32(iPtr));         // Output: 20
 ```
 
@@ -94,12 +94,12 @@ heap, fixed explicitly using `fixed` or `GCHandle.Alloc`.
 ```csharp
 Memory<Int32> values = new Int32[]
 {
-    0x650048,   // In UTF-16: He
-    0x6c006c,   // In UTF-16: ll
-    0x20006f,   // In UTF-16: o 
-    0x6f0057,   // In UTF-16: wo
-    0x6c0072,   // In UTF-16: rl
-    0x64        // In UTF-16: d
+    0x650048,   // Hardcoded UTF-16: "He"
+    0x6c006c,   // Hardcoded UTF-16: "ll"
+    0x20006f,   // Hardcoded UTF-16: "o "
+    0x6f0057,   // Hardcoded UTF-16: "wo"
+    0x6c0072,   // Hardcoded UTF-16: "rl"
+    0x64        // Hardcoded UTF-16: "d"
 };
 using MemoryHandle handle = values.Pin();
 
@@ -107,7 +107,7 @@ GC.Collect();
 GC.WaitForFullGCComplete();
 
 IntPtr u16Ptr = values.Span.GetUnsafeIntPtr();
-Console.WriteLine(Marshal.PtrToStringUni(u16Ptr));  // Output: Hello world
+Console.WriteLine(Marshal.PtrToStringUni(u16Ptr));  // Output: "Hello world"
 ```
 
 ---

--- a/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/UnmanagedValueExtensions.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/UnmanagedValueExtensions.cs
@@ -8,6 +8,53 @@
 public static partial class UnmanagedValueExtensions
 {
 	/// <summary>
+	/// Rents and pins an array of minimum <paramref name="count"/> elements from <paramref name="arrayPool"/>,
+	/// ensuring a safe context for accessing the fixed memory.
+	/// </summary>
+	/// <typeparam name="T">
+	/// The unmanaged type from which the contiguous region of memory will be fixed.
+	/// </typeparam>
+	/// <param name="arrayPool">A <see cref="ArrayPool{T}"/> instance.</param>
+	/// <param name="count">Minimum size of rented array.</param>
+	/// <param name="clearArray">Indicates whether the contents of the buffer should be cleared before reuse.</param>
+	/// <returns>An <see cref="IFixedContext{T}.IDisposable"/> instance representing the pinned memory.</returns>
+	/// <remarks>
+	/// This method pins the memory to prevent the garbage collector from moving it, which is essential for safe
+	/// operations on unmanaged memory.
+	/// Ensure that the <see cref="IDisposable"/> object returned is properly disposed to release the pinned memory
+	/// and avoid memory leaks.
+	/// </remarks>
+	[ExcludeFromCodeCoverage]
+	public static IFixedContext<T>.IDisposable RentFixed<T>(this ArrayPool<T> arrayPool, Int32 count,
+		Boolean clearArray = false) where T : unmanaged
+		=> arrayPool.RentFixed(count, clearArray, out _);
+	/// <summary>
+	/// Rents and pins an array of minimum <paramref name="count"/> elements from <paramref name="arrayPool"/>,
+	/// ensuring a safe context for accessing the fixed memory.
+	/// </summary>
+	/// <typeparam name="T">
+	/// The unmanaged type from which the contiguous region of memory will be fixed.
+	/// </typeparam>
+	/// <param name="arrayPool">A <see cref="ArrayPool{T}"/> instance.</param>
+	/// <param name="count">Minimum size of rented array.</param>
+	/// <param name="clearArray">Indicates whether the contents of the buffer should be cleared before reuse.</param>
+	/// <param name="arrayLength">Output. Rented array length.</param>
+	/// <returns>An <see cref="IFixedContext{T}.IDisposable"/> instance representing the pinned memory.</returns>
+	/// <remarks>
+	/// This method pins the memory to prevent the garbage collector from moving it, which is essential for safe
+	/// operations on unmanaged memory.
+	/// Ensure that the <see cref="IDisposable"/> object returned is properly disposed to release the pinned memory
+	/// and avoid memory leaks.
+	/// </remarks>
+	public static IFixedContext<T>.IDisposable RentFixed<T>(this ArrayPool<T> arrayPool, Int32 count,
+		Boolean clearArray, out Int32 arrayLength) where T : unmanaged
+	{
+		FixedRentedContext<T> result = new(arrayPool, count, clearArray);
+		arrayLength = result.Array.Length;
+		return result;
+	}
+
+	/// <summary>
 	/// Converts a given <see langword="unmanaged"/> value of type <typeparamref name="T"/> into an array of
 	/// <see cref="Byte"/>.
 	/// </summary>

--- a/src/Test/Rxmxnx.PInvoke.Buffers.Tests/Buffers/NonBinarySpaceTests.cs
+++ b/src/Test/Rxmxnx.PInvoke.Buffers.Tests/Buffers/NonBinarySpaceTests.cs
@@ -8,9 +8,8 @@ public sealed class NonBinarySpaceTests
 	internal void InvalidTest()
 	{
 		Assert.IsType<InvalidOperationException>(
-			Assert.Throws<TypeInitializationException>(BufferManager
-				                                           .Register<Int32,
-					                                           NonBinarySpace<InternalStruct<Object>, Int32>>)
+			Assert.Throws<TypeInitializationException>(IManagedBuffer<Int32>
+				                                           .GetMetadata<NonBinarySpace<InternalStruct<Object>, Int32>>)
 			      .InnerException);
 		Assert.IsType<InvalidOperationException>(
 			Assert.Throws<TypeInitializationException>(BufferManager
@@ -80,6 +79,12 @@ public sealed class NonBinarySpaceTests
 		Assert.Equal(100, buffer.Span.Length);
 		Assert.Equal(buffer.FullLength, buffer.Span.Length);
 		Assert.Equal(default, buffer.Span[0]);
+		if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+		{
+			Assert.Null(buffer.BufferMetadata);
+			return;
+		}
+
 		Assert.NotNull(buffer.BufferMetadata);
 		Assert.False(buffer.BufferMetadata.IsBinary);
 		Assert.Equal(buffer.Span.Length, buffer.BufferMetadata.Size);

--- a/src/Test/Rxmxnx.PInvoke.Buffers.Tests/MultipleAllocTest.cs
+++ b/src/Test/Rxmxnx.PInvoke.Buffers.Tests/MultipleAllocTest.cs
@@ -109,6 +109,12 @@ public sealed unsafe class MultipleAllocTest
 		Assert.InRange(buffer.Span.Length, 2, Math.Pow(2, 4));
 		Assert.Equal(buffer.FullLength, buffer.Span.Length);
 		Assert.Equal(default, buffer.Span[0]);
+		if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+		{
+			Assert.Null(buffer.BufferMetadata);
+			return;
+		}
+
 		Assert.NotNull(buffer.BufferMetadata);
 		if (typeof(T).IsValueType)
 			Assert.IsAssignableFrom<BufferTypeMetadata<T>>(buffer.BufferMetadata);

--- a/src/Test/Rxmxnx.PInvoke.Buffers.Tests/MultipleAllocTest.cs
+++ b/src/Test/Rxmxnx.PInvoke.Buffers.Tests/MultipleAllocTest.cs
@@ -117,9 +117,9 @@ public sealed unsafe class MultipleAllocTest
 
 		Assert.NotNull(buffer.BufferMetadata);
 		if (typeof(T).IsValueType)
-			Assert.IsAssignableFrom<BufferTypeMetadata<T>>(buffer.BufferMetadata);
+			Assert.IsType<BufferTypeMetadata<T>>(buffer.BufferMetadata, false);
 		else
-			Assert.IsAssignableFrom<BufferTypeMetadata<Object>>(buffer.BufferMetadata);
+			Assert.IsType<BufferTypeMetadata<Object>>(buffer.BufferMetadata, false);
 		Assert.True(buffer.BufferMetadata.IsBinary);
 		Assert.Equal(buffer.Span.Length, buffer.BufferMetadata.Size);
 		Assert.InRange(buffer.BufferMetadata.ComponentCount, 0, 2);

--- a/src/Test/Rxmxnx.PInvoke.Buffers.Tests/PrepareBinaryBufferTest.cs
+++ b/src/Test/Rxmxnx.PInvoke.Buffers.Tests/PrepareBinaryBufferTest.cs
@@ -1,0 +1,15 @@
+namespace Rxmxnx.PInvoke.Tests;
+
+[ExcludeFromCodeCoverage]
+[SuppressMessage("csharpsquid", "S2699")]
+public sealed class PrepareBinaryBufferTest
+{
+	[Fact]
+	internal void Test()
+	{
+		BufferManager.PrepareBinaryBuffer(5);
+		BufferManager.PrepareBinaryBuffer<ValueTuple<Int32, ValueTuple<Int32, Int32>>>(100);
+		BufferManager.PrepareBinaryBuffer<ValueTuple<String, ValueTuple<String, ValueTuple<Int32, Int32>>>>(14);
+		BufferManager.PrepareBinaryBuffer<ValueTuple<Int32, ValueTuple<String, ValueTuple<Int32, Int32>>>>(15);
+	}
+}

--- a/src/Test/Rxmxnx.PInvoke.Buffers.Tests/PrepareBinaryBufferTest.cs
+++ b/src/Test/Rxmxnx.PInvoke.Buffers.Tests/PrepareBinaryBufferTest.cs
@@ -11,5 +11,9 @@ public sealed class PrepareBinaryBufferTest
 		BufferManager.PrepareBinaryBuffer<ValueTuple<Int32, ValueTuple<Int32, Int32>>>(100);
 		BufferManager.PrepareBinaryBuffer<ValueTuple<String, ValueTuple<String, ValueTuple<Int32, Int32>>>>(14);
 		BufferManager.PrepareBinaryBuffer<ValueTuple<Int32, ValueTuple<String, ValueTuple<Int32, Int32>>>>(15);
+
+		BufferManager.PrepareBinaryBufferNullable<ValueTuple<Int32, ValueTuple<Int32, Int32>>>(100);
+		BufferManager.PrepareBinaryBufferNullable<ValueTuple<String, ValueTuple<String, ValueTuple<Int32, Int32>>>>(14);
+		BufferManager.PrepareBinaryBufferNullable<ValueTuple<Int32, ValueTuple<String, ValueTuple<Int32, Int32>>>>(15);
 	}
 }

--- a/src/Test/Rxmxnx.PInvoke.Buffers.Tests/Rxmxnx.PInvoke.Buffers.Tests.csproj
+++ b/src/Test/Rxmxnx.PInvoke.Buffers.Tests/Rxmxnx.PInvoke.Buffers.Tests.csproj
@@ -28,8 +28,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
         <PackageReference Include="System.Net.Http" Version="4.3.4"/>
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
-        <PackageReference Include="xunit" Version="2.9.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Test/Rxmxnx.PInvoke.Buffers.Tests/UnitAllocTest.cs
+++ b/src/Test/Rxmxnx.PInvoke.Buffers.Tests/UnitAllocTest.cs
@@ -57,6 +57,11 @@ public sealed unsafe class UnitAllocTest
 		Assert.Equal(1, buffer.Span.Length);
 		Assert.Equal(1, buffer.FullLength);
 		Assert.Equal(default, buffer.Span[0]);
+		if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+		{
+			Assert.Null(buffer.BufferMetadata);
+			return;
+		}
 		Assert.NotNull(buffer.BufferMetadata);
 		Assert.Equal(typeof(T).IsValueType ? typeof(Atomic<T>) : typeof(Atomic<Object>),
 		             buffer.BufferMetadata.BufferType);

--- a/src/Test/Rxmxnx.PInvoke.CString.Tests/Rxmxnx.PInvoke.CString.Tests.csproj
+++ b/src/Test/Rxmxnx.PInvoke.CString.Tests/Rxmxnx.PInvoke.CString.Tests.csproj
@@ -29,8 +29,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
         <PackageReference Include="System.Net.Http" Version="4.3.4"/>
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
-        <PackageReference Include="xunit" Version="2.9.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Test/Rxmxnx.PInvoke.Common.Tests/Rxmxnx.PInvoke.Common.Tests.csproj
+++ b/src/Test/Rxmxnx.PInvoke.Common.Tests/Rxmxnx.PInvoke.Common.Tests.csproj
@@ -29,8 +29,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
         <PackageReference Include="System.Net.Http" Version="4.3.4"/>
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
-        <PackageReference Include="xunit" Version="2.9.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Test/Rxmxnx.PInvoke.Extensions.Tests/PointerExtensionsTests/GetUnsafeSpanTest.cs
+++ b/src/Test/Rxmxnx.PInvoke.Extensions.Tests/PointerExtensionsTests/GetUnsafeSpanTest.cs
@@ -61,6 +61,9 @@ public sealed class GetUnsafeSpanTest
 			Assert.Equal(input, intPtr.GetUnsafeArray<T>(input.Length));
 			Assert.Equal(input, uintPtr.GetUnsafeArray<T>(input.Length));
 			Assert.Equal(input, handle.GetUnsafeArray<T>(input.Length));
+			Assert.True(p == handle.Pointer);
+			Assert.Equal(intPtr, handle.ToIntPtr());
+			Assert.Equal(uintPtr, handle.ToUIntPtr());
 		}
 
 		GetUnsafeSpanTest.MemoryTest(input);

--- a/src/Test/Rxmxnx.PInvoke.Extensions.Tests/Rxmxnx.PInvoke.Extensions.Tests.csproj
+++ b/src/Test/Rxmxnx.PInvoke.Extensions.Tests/Rxmxnx.PInvoke.Extensions.Tests.csproj
@@ -28,8 +28,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
         <PackageReference Include="System.Net.Http" Version="4.3.4"/>
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
-        <PackageReference Include="xunit" Version="2.9.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Test/Rxmxnx.PInvoke.Extensions.Tests/UnmanagedValueExtensionsTest/RentFixedTest.cs
+++ b/src/Test/Rxmxnx.PInvoke.Extensions.Tests/UnmanagedValueExtensionsTest/RentFixedTest.cs
@@ -1,0 +1,97 @@
+namespace Rxmxnx.PInvoke.Tests.UnmanagedValueExtensionsTest;
+
+[ExcludeFromCodeCoverage]
+[SuppressMessage("csharpsquid", "S2699")]
+public sealed class RentFixedTest
+{
+	private static readonly IFixture fixture = new Fixture();
+
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void ByteTest(Int32 size) => TestClass<Byte>.Test(size);
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void CharTest(Int32 size) => TestClass<Char>.Test(size);
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void DateTimeTest(Int32 size) => TestClass<DateTime>.Test(size);
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void DecimalTest(Int32 size) => TestClass<Decimal>.Test(size);
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void DoubleTest(Int32 size) => TestClass<Double>.Test(size);
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void GuidTest(Int32 size) => TestClass<Guid>.Test(size);
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void HalfTest(Int32 size) => TestClass<Half>.Test(size);
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void Int16Test(Int32 size) => TestClass<Int16>.Test(size);
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void Int32Test(Int32 size) => TestClass<Int32>.Test(size);
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void Int64Test(Int32 size) => TestClass<Int64>.Test(size);
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void SByteTest(Int32 size) => TestClass<SByte>.Test(size);
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void UInt16Test(Int32 size) => TestClass<UInt16>.Test(size);
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void UInt32Test(Int32 size) => TestClass<UInt32>.Test(size);
+	[Theory]
+	[InlineData(10)]
+	[InlineData(100)]
+	[InlineData(1000)]
+	internal void UInt64Test(Int32 size) => TestClass<UInt64>.Test(size);
+
+	private static class TestClass<T> where T : unmanaged
+	{
+		private static readonly ArrayPool<T> pool = ArrayPool<T>.Create(1024 * Unsafe.SizeOf<T>(), 50);
+
+		public static void Test(Int32 size)
+		{
+			T[] arr = TestClass<T>.pool.Rent(size);
+			RentFixedTest.fixture.CreateMany<T>(arr.Length).ToArray().CopyTo(arr.AsSpan());
+			TestClass<T>.pool.Return(arr); // Ensure this array is used.
+
+			using IFixedContext<T>.IDisposable ctx = TestClass<T>.pool.RentFixed(size, true, out Int32 arrayLength);
+			Assert.Equal(arr.Length, arrayLength);
+			Assert.Equal(size, ctx.Values.Length);
+			Assert.True(Unsafe.AreSame(ref ctx.ValuePointer.Reference, ref MemoryMarshal.GetReference(arr.AsSpan())));
+			Assert.True(ctx.Values.SequenceEqual(arr.AsSpan()[..size]));
+		}
+	}
+}


### PR DESCRIPTION
* Buffers for unmanaged types always use stackalloc.
* Prepare binary buffer.
* Empty fixed context singleton.
* Documentation improvements.