### PR TITLE
Fix Mobile Memory Inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -2468,6 +2468,13 @@ Additional functionality for working with memory blocks.
 
   **Note:** This function is currently available only on Windows, Linux, and macOS.
   </details>
+- <details>
+  <summary>MayBeNonLiteral&lt;T&gt;(this ReadOnlySpan&lt;T&gt;)</summary>
+
+  Indicates whether the given `ReadOnlySpan<T>` instance represents memory that is not part of a hardcoded literal.
+
+  **Note:** If the platform is unsupported or an inspection error occurs, the method returns true.
+  </details>
 
 - <details>
   <summary>GetUnsafeValPtr&lt;T&gt;(this Span&lt;T&gt;)</summary>

--- a/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/CString/Marshaller.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.CString.Intermediate/CString/Marshaller.cs
@@ -95,18 +95,11 @@ public unsafe partial class CString
 					return this._pointer;
 				}
 
-				try
+				if (this._managed.IsFunction && !MemoryInspector.MayBeNonLiteral(utf8Span))
 				{
-					if (this._managed.IsFunction && MemoryInspector.Instance.IsLiteral(utf8Span))
-					{
-						// If the CString is a literal, we can use the pointer directly.
-						this._pointer = (IntPtr)Unsafe.AsPointer(ref MemoryMarshal.GetReference(utf8Span));
-						return this._pointer;
-					}
-				}
-				catch (PlatformNotSupportedException)
-				{
-					// Ignore 
+					// If the CString is a literal, we can use the pointer directly.
+					this._pointer = (IntPtr)Unsafe.AsPointer(ref MemoryMarshal.GetReference(utf8Span));
+					return this._pointer;
 				}
 			}
 

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/MemoryInspector.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/MemoryInspector.cs
@@ -50,6 +50,9 @@ internal abstract partial class MemoryInspector
 	/// <see langword="true"/> if the current execution is occurring on a Windows-compatible platform; otherwise,
 	/// <see langword="false"/>.
 	/// </returns>
+#if !PACKAGE
+	[ExcludeFromCodeCoverage]
+#endif
 	private static Boolean IsWindowsPlatform()
 #if NET5_0_OR_GREATER
 		=> OperatingSystem.IsWindows();
@@ -63,6 +66,9 @@ internal abstract partial class MemoryInspector
 	/// <see langword="true"/> if the current execution is occurring on a Linux-compatible platform; otherwise,
 	/// <see langword="false"/>.
 	/// </returns>
+#if !PACKAGE
+	[ExcludeFromCodeCoverage]
+#endif
 	private static Boolean IsLinuxPlatform()
 #if NET5_0_OR_GREATER
 		=> OperatingSystem.IsLinux() || OperatingSystem.IsAndroid();
@@ -77,6 +83,9 @@ internal abstract partial class MemoryInspector
 	/// <see langword="true"/> if the current execution is occurring on a macOS-compatible platform; otherwise,
 	/// <see langword="false"/>.
 	/// </returns>
+#if !PACKAGE
+	[ExcludeFromCodeCoverage]
+#endif
 	private static Boolean IsMacPlatform()
 #if NET5_0_OR_GREATER
 		=> OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() ||
@@ -94,6 +103,9 @@ internal abstract partial class MemoryInspector
 	/// <see langword="true"/> if the current execution is occurring on Mac Catalyst platform; otherwise,
 	/// <see langword="false"/>.
 	/// </returns>
+#if !PACKAGE
+	[ExcludeFromCodeCoverage]
+#endif
 	private static Boolean IsMacCatalyst()
 #if NET6_0_OR_GREATER
 		=> OperatingSystem.IsMacCatalyst();

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/MemoryInspector.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/MemoryInspector.cs
@@ -33,15 +33,41 @@ internal abstract partial class MemoryInspector
 	}
 
 	/// <summary>
-	/// Indicates whether current span represents a literal or hardcoded memory region.
+	/// Indicates whether given span represents a literal or hardcoded memory region.
 	/// </summary>
 	/// <typeparam name="T">Type of items in <paramref name="span"/>.</typeparam>
 	/// <param name="span">A read-only span of <typeparamref name="T"/> items.</param>
 	/// <returns>
-	/// <see langword="true"/> if current span represents a constant, literal o hardcoded memory region;
+	/// <see langword="true"/> if the given span represents a literal o hardcoded memory region;
 	/// otherwise, <see langword="false"/>.
 	/// </returns>
 	public abstract Boolean IsLiteral<T>(ReadOnlySpan<T> span);
+
+	/// <summary>
+	/// Indicates whether the given span represents memory that is not part of a hardcoded literal.
+	/// </summary>
+	/// <typeparam name="T">Type of items in <paramref name="span"/>.</typeparam>
+	/// <param name="span">A read-only span of <typeparamref name="T"/> items.</param>
+	/// <returns>
+	/// <see langword="true"/> if the given span represents memory that is not part of a hardcoded literal;
+	/// otherwise, <see langword="false"/>.
+	/// </returns>
+#if !PACKAGE
+	[ExcludeFromCodeCoverage]
+#endif
+	public static Boolean MayBeNonLiteral<T>(ReadOnlySpan<T> span)
+	{
+		try
+		{
+			if (MemoryInspector.instance is not null)
+				return !MemoryInspector.instance.IsLiteral(span);
+		}
+		catch (Exception)
+		{
+			// Ignore
+		}
+		return true;
+	}
 
 	/// <summary>
 	/// Indicates whether the current execution is occurring on a Windows-compatible platform.

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/MemoryInspector.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/MemoryInspector.cs
@@ -24,7 +24,7 @@ internal abstract partial class MemoryInspector
 #endif
 	static MemoryInspector()
 	{
-		if (OperatingSystem.IsWindows())
+		if (MemoryInspector.IsWindowsPlatform())
 			MemoryInspector.instance = new Windows();
 		else if (MemoryInspector.IsLinuxPlatform())
 			MemoryInspector.instance = new Linux();
@@ -43,6 +43,19 @@ internal abstract partial class MemoryInspector
 	/// </returns>
 	public abstract Boolean IsLiteral<T>(ReadOnlySpan<T> span);
 
+	/// <summary>
+	/// Indicates whether the current execution is occurring on a Windows-compatible platform.
+	/// </summary>
+	/// <returns>
+	/// <see langword="true"/> if the current execution is occurring on a Windows-compatible platform; otherwise,
+	/// <see langword="false"/>.
+	/// </returns>
+	private static Boolean IsWindowsPlatform()
+#if NET5_0_OR_GREATER
+		=> OperatingSystem.IsWindows();
+#else
+		=> RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#endif
 	/// <summary>
 	/// Indicates whether the current execution is occurring on a Linux-compatible platform.
 	/// </summary>
@@ -67,11 +80,24 @@ internal abstract partial class MemoryInspector
 	private static Boolean IsMacPlatform()
 #if NET5_0_OR_GREATER
 		=> OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() ||
-			OperatingSystem.IsMacCatalyst();
+			MemoryInspector.IsMacCatalyst();
 #else
 		=> RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
 			RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")) ||
 			RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS")) ||
-			RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"));
+			MemoryInspector.IsMacCatalyst();
+#endif
+	/// <summary>
+	/// Indicates whether the current execution is occurring on Mac Catalyst platform.
+	/// </summary>
+	/// <returns>
+	/// <see langword="true"/> if the current execution is occurring on Mac Catalyst platform; otherwise,
+	/// <see langword="false"/>.
+	/// </returns>
+	private static Boolean IsMacCatalyst()
+#if NET6_0_OR_GREATER
+		=> OperatingSystem.IsMacCatalyst();
+#else
+		=> RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"));
 #endif
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/MemoryInspector.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/MemoryInspector.cs
@@ -31,7 +31,7 @@ internal abstract partial class MemoryInspector
 #endif
 			MemoryInspector.instance = new Windows();
 #if NET5_0_OR_GREATER
-		else if (OperatingSystem.IsLinux())
+		else if (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid())
 #else
 		else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
 #endif

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/MemoryInspector.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/MemoryInspector.cs
@@ -24,24 +24,12 @@ internal abstract partial class MemoryInspector
 #endif
 	static MemoryInspector()
 	{
-#if NET5_0_OR_GREATER
 		if (OperatingSystem.IsWindows())
-#else
-		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-#endif
 			MemoryInspector.instance = new Windows();
-#if NET5_0_OR_GREATER
-		else if (OperatingSystem.IsLinux() || OperatingSystem.IsAndroid())
-#else
-		else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-#endif
+		else if (MemoryInspector.IsLinuxPlatform())
 			MemoryInspector.instance = new Linux();
-#if NET5_0_OR_GREATER
-		else if (!OperatingSystem.IsBrowser() && !OperatingSystem.IsFreeBSD() && !OperatingSystem.IsWatchOS())
-#else
-		else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-#endif
-			MemoryInspector.instance = new Mac(); // OSX
+		else if (MemoryInspector.IsMacPlatform())
+			MemoryInspector.instance = new Mac();
 	}
 
 	/// <summary>
@@ -54,4 +42,36 @@ internal abstract partial class MemoryInspector
 	/// otherwise, <see langword="false"/>.
 	/// </returns>
 	public abstract Boolean IsLiteral<T>(ReadOnlySpan<T> span);
+
+	/// <summary>
+	/// Indicates whether the current execution is occurring on a Linux-compatible platform.
+	/// </summary>
+	/// <returns>
+	/// <see langword="true"/> if the current execution is occurring on a Linux-compatible platform; otherwise,
+	/// <see langword="false"/>.
+	/// </returns>
+	private static Boolean IsLinuxPlatform()
+#if NET5_0_OR_GREATER
+		=> OperatingSystem.IsLinux() || OperatingSystem.IsAndroid();
+#else
+		=> RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+			RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
+#endif
+	/// <summary>
+	/// Indicates whether the current execution is occurring on a macOS-compatible platform.
+	/// </summary>
+	/// <returns>
+	/// <see langword="true"/> if the current execution is occurring on a macOS-compatible platform; otherwise,
+	/// <see langword="false"/>.
+	/// </returns>
+	private static Boolean IsMacPlatform()
+#if NET5_0_OR_GREATER
+		=> OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() ||
+			OperatingSystem.IsMacCatalyst();
+#else
+		=> RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+			RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")) ||
+			RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS")) ||
+			RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"));
+#endif
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/MemoryBlockExtensions.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Extensions.Intermediate/MemoryBlockExtensions.cs
@@ -12,12 +12,12 @@
 public static unsafe partial class MemoryBlockExtensions
 {
 	/// <summary>
-	/// Indicates whether current span represents a literal or hardcoded memory region.
+	/// Indicates whether the current span represents a literal or hardcoded memory region.
 	/// </summary>
 	/// <typeparam name="T">Type of items in <paramref name="span"/>.</typeparam>
 	/// <param name="span">A span of <typeparamref name="T"/> items.</param>
 	/// <returns>
-	/// <see langword="true"/> if current span represents a constant, literal o hardcoded memory region;
+	/// <see langword="true"/> if the current span represents a literal o hardcoded memory region;
 	/// otherwise, <see langword="false"/>.
 	/// </returns>
 #if !PACKAGE
@@ -30,16 +30,33 @@ public static unsafe partial class MemoryBlockExtensions
 		return readOnlySpan.IsLiteral();
 	}
 	/// <summary>
-	/// Indicates whether current span represents a literal or hardcoded memory region.
+	/// Indicates whether the current span represents a literal or hardcoded memory region.
 	/// </summary>
 	/// <typeparam name="T">Type of items in <paramref name="span"/>.</typeparam>
 	/// <param name="span">A read-only span of <typeparamref name="T"/> items.</param>
 	/// <returns>
-	/// <see langword="true"/> if current span represents a constant, literal o hardcoded memory region;
+	/// <see langword="true"/> if the current span represents a literal o hardcoded memory region;
 	/// otherwise, <see langword="false"/>.
 	/// </returns>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static Boolean IsLiteral<T>(this ReadOnlySpan<T> span) => MemoryInspector.Instance.IsLiteral(span);
+
+	/// <summary>
+	/// Indicates whether the current span represents memory that is not part of a hardcoded literal.
+	/// </summary>
+	/// <typeparam name="T">Type of items in <paramref name="span"/>.</typeparam>
+	/// <param name="span">A read-only span of <typeparamref name="T"/> items.</param>
+	/// <returns>
+	/// <see langword="true"/> if the current span represents memory that is not part of a hardcoded literal;
+	/// otherwise, <see langword="false"/>.
+	/// </returns>
+	/// <remarks>
+	/// On unsupported platforms or in case of inspection errors, this method will always return <see langword="true"/>.
+	/// </remarks>
+#if !PACKAGE
+	[ExcludeFromCodeCoverage]
+#endif
+	public static Boolean MayBeNonLiteral<T>(this ReadOnlySpan<T> span) => MemoryInspector.Instance.IsLiteral(span);
 
 	/// <summary>
 	/// Retrieves an unsafe <see cref="ValPtr{T}"/> pointer from <see cref="Span{T}"/> instance.


### PR DESCRIPTION
Currently, the memory inspection feature only supports Windows, Linux, and macOS. However, Android works with the Linux implementation, and Mac Catalyst, tvOS, and iOS work with the macOS implementation, so they need to be included.

Linux-Bionic is not Android, and has therefore always been supported.

* Add MayBeNonLiteral extension. 