### PR TITLE
Fix Critical Issue in FixedValueHandle and Update Tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,9 @@ jobs:
           sudo apt install mono-complete mono-vbnc mono-dbg gdb libssl3
           mv ./ApplicationTest src/ApplicationTest
       - name: Clean test results
-        run: rm -rf TestResults/
+        run: |
+          rm -rf TestResults/
+          dotnet clean src --configuration Release
       - name: Build and analyze Sonar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/AssemblyPatchers.props
+++ b/AssemblyPatchers.props
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.4.0"/>
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.9.6"/>
     </ItemGroup>
 
     <Import Project="MonoCecil.props"/>

--- a/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Package.appxmanifest
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Package.appxmanifest
@@ -1,13 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
-<Package
-        xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
-        xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
-        xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-        xmlns:uap18="http://schemas.microsoft.com/appx/manifest/uap/windows10/18"
-        IgnorableNamespaces="uap mp uap18">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+         xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+         xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+         xmlns:uap18="http://schemas.microsoft.com/appx/manifest/uap/windows10/18"
+         IgnorableNamespaces="uap mp uap18">
 
-    <Identity Name="487a3b81-026f-402b-88fa-50ded50dd7d9" Publisher="CN=josephmoresena"/>
+    <Identity Name="487a3b81-026f-402b-88fa-50ded50dd7d9" Publisher="CN=josephmoresena" Version="1.0.0.0"/>
 
     <mp:PhoneIdentity PhoneProductId="487a3b81-026f-402b-88fa-50ded50dd7d9"
                       PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
@@ -27,16 +26,13 @@
     </Resources>
 
     <Applications>
-        <Application Id="App"
-                     Executable="$targetnametoken$.exe"
-                     EntryPoint="Rxmxnx.PInvoke.ApplicationTest.Windows.App" uap18:RuntimeBehavior="windowsApp"
-                     uap18:TrustLevel="appContainer">
-            <uap:VisualElements
-                    DisplayName="Rxmxnx.PInvoke.ApplicationTest.Windows"
-                    Square150x150Logo="Assets\Square150x150Logo.png"
-                    Square44x44Logo="Assets\Square44x44Logo.png"
-                    Description="Rxmxnx.PInvoke.ApplicationTest.Windows"
-                    BackgroundColor="transparent">
+        <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="Rxmxnx.PInvoke.ApplicationTest.Windows.App"
+                     uap18:RuntimeBehavior="windowsApp" uap18:TrustLevel="appContainer">
+            <uap:VisualElements DisplayName="Rxmxnx.PInvoke.ApplicationTest.Windows"
+                                Square150x150Logo="Assets\Square150x150Logo.png"
+                                Square44x44Logo="Assets\Square44x44Logo.png"
+                                Description="Rxmxnx.PInvoke.ApplicationTest.Windows"
+                                BackgroundColor="transparent">
                 <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png"/>
                 <uap:SplashScreen Image="Assets\SplashScreen.png"/>
             </uap:VisualElements>

--- a/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Package.appxmanifest
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Package.appxmanifest
@@ -7,10 +7,7 @@
         xmlns:uap18="http://schemas.microsoft.com/appx/manifest/uap/windows10/18"
         IgnorableNamespaces="uap mp uap18">
 
-    <Identity
-            Name="487a3b81-026f-402b-88fa-50ded50dd7d9"
-            Publisher="CN=josephmoresena"
-            Version="1.0.0.0"/>
+    <Identity Name="487a3b81-026f-402b-88fa-50ded50dd7d9" Publisher="CN=josephmoresena"/>
 
     <mp:PhoneIdentity PhoneProductId="487a3b81-026f-402b-88fa-50ded50dd7d9"
                       PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
@@ -22,7 +19,7 @@
     </Properties>
 
     <Dependencies>
-        <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0"/>
+        <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.16299.0" MaxVersionTested="10.0.16299.0"/>
     </Dependencies>
 
     <Resources>

--- a/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
@@ -21,6 +21,7 @@
 		<WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
 		<AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
 		<PackageCertificateThumbprint>BE0F8266E600E117C72C20616FCCE5570EE1254C</PackageCertificateThumbprint>
+		<Version Condition="'$(PackageVersion)' = ''">$(PackageVersion)</Version>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
 		<DebugSymbols>true</DebugSymbols>

--- a/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
@@ -185,13 +185,7 @@
         <AppxPackageVersion>$(PackageVersion)</AppxPackageVersion>
         <AppxBundlePackageVersion>$(PackageVersion)</AppxBundlePackageVersion>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(UsePackage)' == 'true' And '$(PackageVersion)' == '9999.99.99.99-tmp'">
-        <_Now>$([System.DateTime]::Now.ToString('yyyy.M.d'))</_Now>
-        <_Time>$([System.Int16]::Parse($([System.DateTime]::Now.ToString('Hmm'))))</_Time>
-        <AppxPackageVersion>$(_Now).$(_Time)</AppxPackageVersion>
-        <AppxBundlePackageVersion>$(AppxPackageVersion)</AppxBundlePackageVersion>
-    </PropertyGroup>
-    <Target Name="_PrepareAppxManifest" BeforeTargets="_ValidatePresenceOfAppxManifestItems" Condition="'$(UsePackage)' == 'true'">
+    <Target Name="_PrepareAppxManifest" BeforeTargets="_ValidatePresenceOfAppxManifestItems" Condition="'$(UsePackage)' == 'true' And '$(AppxPackageVersion)' != ''">
         <PropertyGroup>
             <AppxPatchedManifest>$(IntermediateOutputPath)Package.appxmanifest</AppxPatchedManifest>
         </PropertyGroup>

--- a/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
@@ -21,7 +21,7 @@
 		<WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
 		<AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
 		<PackageCertificateThumbprint>BE0F8266E600E117C72C20616FCCE5570EE1254C</PackageCertificateThumbprint>
-		<Version Condition="'$(PackageVersion)' = ''">$(PackageVersion)</Version>
+		<Version Condition="'$(PackageVersion)' != ''">$(PackageVersion)</Version>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
 		<DebugSymbols>true</DebugSymbols>

--- a/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
@@ -1,185 +1,189 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-	<PropertyGroup>
-		<LangVersion>9.0</LangVersion>
-		<Nullable>enable</Nullable>
-		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-		<Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-		<ProjectGuid>{32A26FC7-9B6A-46CC-A178-F77A9AE62EA6}</ProjectGuid>
-		<OutputType>AppContainerExe</OutputType>
-		<AppDesignerFolder>Properties</AppDesignerFolder>
-		<RootNamespace>Rxmxnx.PInvoke.ApplicationTest</RootNamespace>
-		<AssemblyName>Rxmxnx.PInvoke.ApplicationTest.Windows</AssemblyName>
-		<DefaultLanguage>en-US</DefaultLanguage>
-		<TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-		<TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</TargetPlatformVersion>
-		<TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-		<MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
-		<FileAlignment>512</FileAlignment>
-		<ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-		<WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
-		<AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
-		<PackageCertificateThumbprint>BE0F8266E600E117C72C20616FCCE5570EE1254C</PackageCertificateThumbprint>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-		<DebugSymbols>true</DebugSymbols>
-		<OutputPath>bin\x86\Debug\</OutputPath>
-		<DefineConstants>TRACE;DEBUG;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>full</DebugType>
-		<PlatformTarget>x86</PlatformTarget>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-		<Prefer32Bit>true</Prefer32Bit>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-		<OutputPath>bin\x86\Release\</OutputPath>
-		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
-		<Optimize>true</Optimize>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>pdbonly</DebugType>
-		<PlatformTarget>x86</PlatformTarget>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-		<Prefer32Bit>true</Prefer32Bit>
-		<UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
-		<DebugSymbols>true</DebugSymbols>
-		<OutputPath>bin\ARM\Debug\</OutputPath>
-		<DefineConstants>TRACE;DEBUG;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>full</DebugType>
-		<PlatformTarget>ARM</PlatformTarget>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-		<Prefer32Bit>true</Prefer32Bit>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
-		<OutputPath>bin\ARM\Release\</OutputPath>
-		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
-		<Optimize>true</Optimize>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>pdbonly</DebugType>
-		<PlatformTarget>ARM</PlatformTarget>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-		<Prefer32Bit>true</Prefer32Bit>
-		<UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
-		<DebugSymbols>true</DebugSymbols>
-		<OutputPath>bin\ARM64\Debug\</OutputPath>
-		<DefineConstants>TRACE;DEBUG;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>full</DebugType>
-		<PlatformTarget>ARM64</PlatformTarget>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-		<Prefer32Bit>true</Prefer32Bit>
-		<UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
-		<OutputPath>bin\ARM64\Release\</OutputPath>
-		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
-		<Optimize>true</Optimize>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>pdbonly</DebugType>
-		<PlatformTarget>ARM64</PlatformTarget>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-		<Prefer32Bit>true</Prefer32Bit>
-		<UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-		<DebugSymbols>true</DebugSymbols>
-		<OutputPath>bin\x64\Debug\</OutputPath>
-		<DefineConstants>TRACE;DEBUG;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>full</DebugType>
-		<PlatformTarget>x64</PlatformTarget>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-		<Prefer32Bit>true</Prefer32Bit>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-		<OutputPath>bin\x64\Release\</OutputPath>
-		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
-		<Optimize>true</Optimize>
-		<NoWarn>;2008</NoWarn>
-		<DebugType>pdbonly</DebugType>
-		<PlatformTarget>x64</PlatformTarget>
-		<UseVSHostingProcess>false</UseVSHostingProcess>
-		<ErrorReport>prompt</ErrorReport>
-		<Prefer32Bit>true</Prefer32Bit>
-		<UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
-	</PropertyGroup>
-	<PropertyGroup>
-		<RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-	</PropertyGroup>
-	<ItemGroup>
-		<Compile Include="App.xaml.cs">
-			<DependentUpon>App.xaml</DependentUpon>
-		</Compile>
-		<Compile Include="MainPage.xaml.cs">
-			<DependentUpon>MainPage.xaml</DependentUpon>
-		</Compile>
-		<Compile Include="Properties\AssemblyInfo.cs" />
-	</ItemGroup>
-	<ItemGroup>
-		<AppxManifest Include="Package.appxmanifest">
-			<SubType>Designer</SubType>
-		</AppxManifest>
-	</ItemGroup>
-	<ItemGroup>
-		<Content Include="Properties\Default.rd.xml" />
-		<Content Include="Assets\LockScreenLogo.scale-200.png" />
-		<Content Include="Assets\SplashScreen.scale-200.png" />
-		<Content Include="Assets\Square150x150Logo.scale-200.png" />
-		<Content Include="Assets\Square44x44Logo.scale-200.png" />
-		<Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
-		<Content Include="Assets\StoreLogo.png" />
-		<Content Include="Assets\Wide310x150Logo.scale-200.png" />
-	</ItemGroup>
-	<ItemGroup>
-		<ApplicationDefinition Include="App.xaml">
-			<Generator>MSBuild:Compile</Generator>
-			<SubType>Designer</SubType>
-		</ApplicationDefinition>
-		<Page Include="MainPage.xaml">
-			<Generator>MSBuild:Compile</Generator>
-			<SubType>Designer</SubType>
-		</Page>
-	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-			<Version>6.2.14</Version>
-		</PackageReference>
-		<PackageReference Include="Microsoft.Net.Native.Compiler">
-			<Version>2.2.12-rel-33220-00</Version>
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
+    <PropertyGroup>
+        <LangVersion>9.0</LangVersion>
+        <Nullable>enable</Nullable>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+        <ProjectGuid>{32A26FC7-9B6A-46CC-A178-F77A9AE62EA6}</ProjectGuid>
+        <OutputType>AppContainerExe</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <RootNamespace>Rxmxnx.PInvoke.ApplicationTest</RootNamespace>
+        <AssemblyName>Rxmxnx.PInvoke.ApplicationTest.Windows</AssemblyName>
+        <DefaultLanguage>en-US</DefaultLanguage>
+        <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+        <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</TargetPlatformVersion>
+        <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+        <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+        <FileAlignment>512</FileAlignment>
+        <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+        <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
+        <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
+        <PackageCertificateThumbprint>BE0F8266E600E117C72C20616FCCE5570EE1254C</PackageCertificateThumbprint>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+        <DebugSymbols>true</DebugSymbols>
+        <OutputPath>bin\x86\Debug\</OutputPath>
+        <DefineConstants>TRACE;DEBUG;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>full</DebugType>
+        <PlatformTarget>x86</PlatformTarget>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+        <Prefer32Bit>true</Prefer32Bit>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+        <OutputPath>bin\x86\Release\</OutputPath>
+        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
+        <Optimize>true</Optimize>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>pdbonly</DebugType>
+        <PlatformTarget>x86</PlatformTarget>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+        <Prefer32Bit>true</Prefer32Bit>
+        <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+        <DebugSymbols>true</DebugSymbols>
+        <OutputPath>bin\ARM\Debug\</OutputPath>
+        <DefineConstants>TRACE;DEBUG;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>full</DebugType>
+        <PlatformTarget>ARM</PlatformTarget>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+        <Prefer32Bit>true</Prefer32Bit>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+        <OutputPath>bin\ARM\Release\</OutputPath>
+        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
+        <Optimize>true</Optimize>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>pdbonly</DebugType>
+        <PlatformTarget>ARM</PlatformTarget>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+        <Prefer32Bit>true</Prefer32Bit>
+        <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
+        <DebugSymbols>true</DebugSymbols>
+        <OutputPath>bin\ARM64\Debug\</OutputPath>
+        <DefineConstants>TRACE;DEBUG;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>full</DebugType>
+        <PlatformTarget>ARM64</PlatformTarget>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+        <Prefer32Bit>true</Prefer32Bit>
+        <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
+        <OutputPath>bin\ARM64\Release\</OutputPath>
+        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
+        <Optimize>true</Optimize>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>pdbonly</DebugType>
+        <PlatformTarget>ARM64</PlatformTarget>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+        <Prefer32Bit>true</Prefer32Bit>
+        <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+        <DebugSymbols>true</DebugSymbols>
+        <OutputPath>bin\x64\Debug\</OutputPath>
+        <DefineConstants>TRACE;DEBUG;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>full</DebugType>
+        <PlatformTarget>x64</PlatformTarget>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+        <Prefer32Bit>true</Prefer32Bit>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+        <OutputPath>bin\x64\Release\</OutputPath>
+        <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;UAP;CSHARP9_0;UAP10_0_16299</DefineConstants>
+        <Optimize>true</Optimize>
+        <NoWarn>;2008</NoWarn>
+        <DebugType>pdbonly</DebugType>
+        <PlatformTarget>x64</PlatformTarget>
+        <UseVSHostingProcess>false</UseVSHostingProcess>
+        <ErrorReport>prompt</ErrorReport>
+        <Prefer32Bit>true</Prefer32Bit>
+        <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+    </PropertyGroup>
+    <PropertyGroup>
+        <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="App.xaml.cs">
+            <DependentUpon>App.xaml</DependentUpon>
+        </Compile>
+        <Compile Include="MainPage.xaml.cs">
+            <DependentUpon>MainPage.xaml</DependentUpon>
+        </Compile>
+        <Compile Include="Properties\AssemblyInfo.cs"/>
+    </ItemGroup>
+    <ItemGroup>
+        <AppxManifest Include="Package.appxmanifest">
+            <SubType>Designer</SubType>
+        </AppxManifest>
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="Properties\Default.rd.xml"/>
+        <Content Include="Assets\LockScreenLogo.scale-200.png"/>
+        <Content Include="Assets\SplashScreen.scale-200.png"/>
+        <Content Include="Assets\Square150x150Logo.scale-200.png"/>
+        <Content Include="Assets\Square44x44Logo.scale-200.png"/>
+        <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png"/>
+        <Content Include="Assets\StoreLogo.png"/>
+        <Content Include="Assets\Wide310x150Logo.scale-200.png"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ApplicationDefinition Include="App.xaml">
+            <Generator>MSBuild:Compile</Generator>
+            <SubType>Designer</SubType>
+        </ApplicationDefinition>
+        <Page Include="MainPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+            <SubType>Designer</SubType>
+        </Page>
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+            <Version>6.2.14</Version>
+        </PackageReference>
+        <PackageReference Include="Microsoft.Net.Native.Compiler">
+            <Version>2.2.12-rel-33220-00</Version>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
     <Import Project="..\..\PackageReference.props"/>
     <ItemGroup>
         <Compile Include="$(MSBuildThisFileDirectory)\..\Rxmxnx.PInvoke.ApplicationTest\**\*.cs"
                  Exclude="$(MSBuildThisFileDirectory)\..\Rxmxnx.PInvoke.ApplicationTest\obj\**\*.cs;$(MSBuildThisFileDirectory)\..\Rxmxnx.PInvoke.ApplicationTest\Program.cs"/>
     </ItemGroup>
-	<ItemGroup>
-		<None Include="Rxmxnx.PInvoke.ApplicationTest.Windows_TemporaryKey.pfx" />
-	</ItemGroup>
-	<PropertyGroup>
-		<ApplicationVersion Condition="'$(UsePackage)' == 'true'">$(PackageVersion)</ApplicationVersion>
-		<AppxPackageVersion Condition="'$(UsePackage)' == 'true'">$(PackageVersion)</AppxPackageVersion>
-		<AppxBundlePackageVersion Condition="'$(UsePackage)' == 'true'">$(PackageVersion)</AppxBundlePackageVersion>
-		<ApplicationVersion Condition="'$(UsePackage)' == 'true'">$(PackageVersion)</ApplicationVersion>
-		<VisualStudioVersion Condition="'$(VisualStudioVersion)' == '' Or '$(VisualStudioVersion)' &lt; '14.0'">14.0</VisualStudioVersion>
-	</PropertyGroup>
-	<Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-	
-	<!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+    <ItemGroup>
+        <None Include="Rxmxnx.PInvoke.ApplicationTest.Windows_TemporaryKey.pfx"/>
+    </ItemGroup>
+    <PropertyGroup Condition="'$(UsePackage)' == 'true' And '$(PackageVersion)' != '9999.99.99.99-tmp'">
+        <AppxPackageVersion>$(PackageVersion)</AppxPackageVersion>
+        <AppxBundlePackageVersion>$(PackageVersion)</AppxBundlePackageVersion>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(UsePackage)' == 'true' And '$(PackageVersion)' == '9999.99.99.99-tmp'">
+        <AppxPackageVersion>$([System.DateTime]::Now.ToString('yyyy.MM.dd.HHmm'))</AppxPackageVersion>
+        <AppxBundlePackageVersion>$(AppxPackageVersion)</AppxBundlePackageVersion>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(VisualStudioVersion)' == '' Or '$(VisualStudioVersion)' &lt; '14.0'">
+        <VisualStudioVersion>14.0</VisualStudioVersion>
+    </PropertyGroup>
+    <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets"/>
+
+    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
@@ -170,8 +170,9 @@
 	<ItemGroup>
 		<None Include="Rxmxnx.PInvoke.ApplicationTest.Windows_TemporaryKey.pfx" />
 	</ItemGroup>
-	<PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
-		<VisualStudioVersion>14.0</VisualStudioVersion>
+	<PropertyGroup>
+		<ApplicationVersion Condition="'$(UsePackage)' == 'true'">$(PackageVersion)</ApplicationVersion>
+		<VisualStudioVersion Condition="'$(VisualStudioVersion)' == '' Or '$(VisualStudioVersion)' &lt; '14.0'">14.0</VisualStudioVersion>
 	</PropertyGroup>
 	<Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
 	

--- a/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <LangVersion>9.0</LangVersion>
         <Nullable>enable</Nullable>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
         <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
         <ProjectGuid>{32A26FC7-9B6A-46CC-A178-F77A9AE62EA6}</ProjectGuid>
         <OutputType>AppContainerExe</OutputType>
@@ -174,17 +174,6 @@
         <VisualStudioVersion>14.0</VisualStudioVersion>
     </PropertyGroup>
     <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets"/>
-    <PropertyGroup Condition="'$(UsePackage)' == 'true' And '$(PackageVersion)' != '9999.99.99.99-tmp'">
-        <AppxPackageVersion>$(PackageVersion)</AppxPackageVersion>
-        <AppxBundlePackageVersion>$(PackageVersion)</AppxBundlePackageVersion>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(UsePackage)' == 'true' And '$(PackageVersion)' == '9999.99.99.99-tmp'">
-        <_Now>$([System.DateTime]::Now.ToString('yyyy.M.d'))</_Now>
-        <_MinutesSinceMidnight>$([System.DateTime]::Now.TimeOfDay.TotalMinutes)</_MinutesSinceMidnight>
-        <AppxPackageVersion>$(_Now).$([System.Math]::Floor($(_MinutesSinceMidnight)))</AppxPackageVersion>
-        <AppxBundlePackageVersion>$(AppxPackageVersion)</AppxBundlePackageVersion>
-    </PropertyGroup>
-
     <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -192,4 +181,27 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+    <PropertyGroup Condition="'$(UsePackage)' == 'true' And '$(PackageVersion)' != '9999.99.99.99-tmp'">
+        <AppxPackageVersion>$(PackageVersion)</AppxPackageVersion>
+        <AppxBundlePackageVersion>$(PackageVersion)</AppxBundlePackageVersion>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(UsePackage)' == 'true' And '$(PackageVersion)' == '9999.99.99.99-tmp'">
+        <_Now>$([System.DateTime]::Now.ToString('yyyy.M.d'))</_Now>
+        <_Time>$([System.Int16]::Parse($([System.DateTime]::Now.ToString('Hmm'))))</_Time>
+        <AppxPackageVersion>$(_Now).$(_Time)</AppxPackageVersion>
+        <AppxBundlePackageVersion>$(AppxPackageVersion)</AppxBundlePackageVersion>
+    </PropertyGroup>
+    <Target Name="_PrepareAppxManifest" BeforeTargets="_ValidatePresenceOfAppxManifestItems" Condition="'$(UsePackage)' == 'true'">
+        <PropertyGroup>
+            <AppxPatchedManifest>$(IntermediateOutputPath)Package.appxmanifest</AppxPatchedManifest>
+        </PropertyGroup>
+        <Copy SourceFiles="@(AppxManifest)" DestinationFiles="$(AppxPatchedManifest)"/>
+        <XmlPoke XmlInputPath="$(AppxPatchedManifest)"
+                 Query="/*[local-name()='Package']/*[local-name()='Identity']/@Version"
+                 Value="$(AppxPackageVersion)"/>
+        <ItemGroup>
+            <AppxManifest Remove="@(AppxManifest)"/>
+            <AppxManifest Include="$(AppxPatchedManifest)"/>
+        </ItemGroup>
+    </Target>
 </Project>

--- a/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
@@ -172,6 +172,9 @@
 	</ItemGroup>
 	<PropertyGroup>
 		<ApplicationVersion Condition="'$(UsePackage)' == 'true'">$(PackageVersion)</ApplicationVersion>
+		<AppxPackageVersion Condition="'$(UsePackage)' == 'true'">$(PackageVersion)</AppxPackageVersion>
+		<AppxBundlePackageVersion Condition="'$(UsePackage)' == 'true'">$(PackageVersion)</AppxBundlePackageVersion>
+		<ApplicationVersion Condition="'$(UsePackage)' == 'true'">$(PackageVersion)</ApplicationVersion>
 		<VisualStudioVersion Condition="'$(VisualStudioVersion)' == '' Or '$(VisualStudioVersion)' &lt; '14.0'">14.0</VisualStudioVersion>
 	</PropertyGroup>
 	<Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />

--- a/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
@@ -21,7 +21,6 @@
 		<WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
 		<AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
 		<PackageCertificateThumbprint>BE0F8266E600E117C72C20616FCCE5570EE1254C</PackageCertificateThumbprint>
-		<Version Condition="'$(PackageVersion)' != ''">$(PackageVersion)</Version>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
 		<DebugSymbols>true</DebugSymbols>

--- a/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
@@ -170,6 +170,10 @@
     <ItemGroup>
         <None Include="Rxmxnx.PInvoke.ApplicationTest.Windows_TemporaryKey.pfx"/>
     </ItemGroup>
+    <PropertyGroup Condition="'$(VisualStudioVersion)' == '' Or '$(VisualStudioVersion)' &lt; '14.0'">
+        <VisualStudioVersion>14.0</VisualStudioVersion>
+    </PropertyGroup>
+    <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets"/>
     <PropertyGroup Condition="'$(UsePackage)' == 'true' And '$(PackageVersion)' != '9999.99.99.99-tmp'">
         <AppxPackageVersion>$(PackageVersion)</AppxPackageVersion>
         <AppxBundlePackageVersion>$(PackageVersion)</AppxBundlePackageVersion>
@@ -180,10 +184,6 @@
         <AppxPackageVersion>$(_Now).$([System.Math]::Floor($(_MinutesSinceMidnight)))</AppxPackageVersion>
         <AppxBundlePackageVersion>$(AppxPackageVersion)</AppxBundlePackageVersion>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(VisualStudioVersion)' == '' Or '$(VisualStudioVersion)' &lt; '14.0'">
-        <VisualStudioVersion>14.0</VisualStudioVersion>
-    </PropertyGroup>
-    <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets"/>
 
     <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.ApplicationTest.Windows/Rxmxnx.PInvoke.ApplicationTest.Windows.csproj
@@ -175,7 +175,9 @@
         <AppxBundlePackageVersion>$(PackageVersion)</AppxBundlePackageVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(UsePackage)' == 'true' And '$(PackageVersion)' == '9999.99.99.99-tmp'">
-        <AppxPackageVersion>$([System.DateTime]::Now.ToString('yyyy.MM.dd.HHmm'))</AppxPackageVersion>
+        <_Now>$([System.DateTime]::Now.ToString('yyyy.M.d'))</_Now>
+        <_MinutesSinceMidnight>$([System.DateTime]::Now.TimeOfDay.TotalMinutes)</_MinutesSinceMidnight>
+        <AppxPackageVersion>$(_Now).$([System.Math]::Floor($(_MinutesSinceMidnight)))</AppxPackageVersion>
         <AppxBundlePackageVersion>$(AppxPackageVersion)</AppxBundlePackageVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(VisualStudioVersion)' == '' Or '$(VisualStudioVersion)' &lt; '14.0'">

--- a/src/ApplicationTest/Rxmxnx.PInvoke.LauncherTest/TestCompiler/CompileAppxArgs.cs
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.LauncherTest/TestCompiler/CompileAppxArgs.cs
@@ -9,8 +9,10 @@ public partial class TestCompiler
 
 		public static void Append(CompileAppxArgs appxArgs, Collection<String> args)
 		{
-			String packageDir = appxArgs.OutputPath.TrimEnd(Path.DirectorySeparatorChar,
-			                                                Path.AltDirectorySeparatorChar) +
+			DateTime dt = DateTime.Now;
+			String appxVersion = $"{dt:yyyy.M.d}.{Int16.Parse(dt.ToString("Hmm"))}";
+			String packageDir =
+				appxArgs.OutputPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) +
 				Path.DirectorySeparatorChar;
 			args.Add("-restore");
 			args.Add(appxArgs.ProjectPath);
@@ -21,6 +23,8 @@ public partial class TestCompiler
 			args.Add("/p:GenerateAppxPackageOnBuild=true");
 			args.Add("/p:AppxPackageSigningEnabled=false");
 			args.Add($"/p:AppxPackageDir={packageDir}");
+			args.Add($"/p:AppxPackageVersion={appxVersion}");
+			args.Add($"/p:AppxBundlePackageVersion={appxVersion}");
 		}
 	}
 }

--- a/src/ApplicationTest/Rxmxnx.PInvoke.LauncherTest/TestCompiler/CompileFrameworkArgs.cs
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.LauncherTest/TestCompiler/CompileFrameworkArgs.cs
@@ -10,11 +10,16 @@ public partial class TestCompiler
 
 		public static void Append(CompileFrameworkArgs compileArgs, Collection<String> args)
 		{
+			DateTime dt = DateTime.Now;
+			String appxVersion = $"{dt:yyyy.M.d}.{Int16.Parse(dt.ToString("HHmm"))}";
+
 			args.Add("build");
 			args.Add(compileArgs.ProjectFile);
 			args.Add("-c");
 			args.Add("Release");
 			args.Add("/p:UsePackage=true");
+			args.Add($"/p:AppxPackageVersion={appxVersion}");
+			args.Add($"/p:AppxBundlePackageVersion={appxVersion}");
 			args.Add("/p:FrameworkLegacyOnly=true");
 			args.Add("/p:BuildInParallel=false");
 			args.Add("-r");

--- a/src/ApplicationTest/Rxmxnx.PInvoke.LauncherTest/TestCompiler/CompileFrameworkArgs.cs
+++ b/src/ApplicationTest/Rxmxnx.PInvoke.LauncherTest/TestCompiler/CompileFrameworkArgs.cs
@@ -10,16 +10,11 @@ public partial class TestCompiler
 
 		public static void Append(CompileFrameworkArgs compileArgs, Collection<String> args)
 		{
-			DateTime dt = DateTime.Now;
-			String appxVersion = $"{dt:yyyy.M.d}.{Int16.Parse(dt.ToString("HHmm"))}";
-
 			args.Add("build");
 			args.Add(compileArgs.ProjectFile);
 			args.Add("-c");
 			args.Add("Release");
 			args.Add("/p:UsePackage=true");
-			args.Add($"/p:AppxPackageVersion={appxVersion}");
-			args.Add($"/p:AppxBundlePackageVersion={appxVersion}");
 			args.Add("/p:FrameworkLegacyOnly=true");
 			args.Add("/p:BuildInParallel=false");
 			args.Add("-r");

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ArrayMemoryManager/ComputeOffset.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ArrayMemoryManager/ComputeOffset.cs
@@ -296,7 +296,7 @@ internal partial class ArrayMemoryManager<T>
 		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
 		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,])![
 			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
-			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], 0];
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], lb[22]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
@@ -310,7 +310,7 @@ internal partial class ArrayMemoryManager<T>
 		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
 		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,])![
 			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
-			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], 0, 0];
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], lb[22], lb[23]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
@@ -324,7 +324,7 @@ internal partial class ArrayMemoryManager<T>
 		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
 		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,])![
 			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
-			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], 0, 0, 0, 0];
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], lb[22], lb[23], lb[24]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
@@ -338,7 +338,7 @@ internal partial class ArrayMemoryManager<T>
 		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
 		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,])![
 			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
-			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], 0, 0, 0, 0, 0];
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], lb[22], lb[23], lb[24], lb[25]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
@@ -352,7 +352,7 @@ internal partial class ArrayMemoryManager<T>
 		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
 		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,])![
 			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
-			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], 0, 0, 0, 0, 0, 0];
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], lb[22], lb[23], lb[24], lb[25], lb[26]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ArrayMemoryManager/ComputeOffset.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/ArrayMemoryManager/ComputeOffset.cs
@@ -10,275 +10,425 @@ internal partial class ArrayMemoryManager<T>
 	/// </summary>
 	/// <param name="array">A <see cref="Array"/> instance.</param>
 	/// <returns>Managed reference to <paramref name="array"/> data.</returns>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset2(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,])![0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,])![lb[0], lb[1]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset3(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,])![0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,])![lb[0], lb[1], lb[2]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset4(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,])![0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,])![lb[0], lb[1], lb[2], lb[3]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
-
-#if !UAP || UAP10_0_16299
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset5(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,,])![0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset6(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,,,])![0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset7(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,,,,])![0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset8(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset9(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef =
+			ref (array as T[,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset10(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef =
+			ref (array as T[,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset11(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef =
+			ref (array as T[,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset12(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef =
+			ref (array as T[,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10],
+			                               lb[11]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset13(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7],
+		                                                         lb[8], lb[9], lb[10], lb[11], lb[12]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset14(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+		                                                          lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset15(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+		                                                           lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+		                                                           lb[14]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset16(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+		                                                            lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+		                                                            lb[14], lb[15]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset17(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+		                                                             lb[7], lb[8], lb[9], lb[10], lb[11], lb[12],
+		                                                             lb[13], lb[14], lb[15], lb[16]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset18(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef =
-			ref (array as T[,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+		                                                              lb[7], lb[8], lb[9], lb[10], lb[11], lb[12],
+		                                                              lb[13], lb[14], lb[15], lb[16], lb[17]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset19(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef =
-			ref (array as T[,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+		                                                               lb[7], lb[8], lb[9], lb[10], lb[11], lb[12],
+		                                                               lb[13], lb[14], lb[15], lb[16], lb[17], lb[18]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset20(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef =
-			ref (array as T[,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+		                                                                lb[7], lb[8], lb[9], lb[10], lb[11], lb[12],
+		                                                                lb[13], lb[14], lb[15], lb[16], lb[17], lb[18],
+		                                                                lb[19]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset21(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef =
-			ref (array as T[,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,])![
+			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset22(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef =
-			ref (array as T[,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,])![
+			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset23(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef =
-			ref (array as T[,,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			                                          0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,])![
+			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], 0];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset24(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef =
-			ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			                                           0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,])![
+			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], 0, 0];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset25(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef =
-			ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			                                            0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,])![
+			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], 0, 0, 0, 0];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset26(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef =
-			ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			                                             0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,])![
+			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], 0, 0, 0, 0, 0];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset27(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
-		ref readonly T dataRef =
-			ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			                                              0, 0, 0, 0, 0, 0];
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
+		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,])![
+			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], 0, 0, 0, 0, 0, 0];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset28(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
 		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,,])![
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], lb[22], lb[23], lb[24], lb[25], lb[26],
+			lb[27]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset29(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
 		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,,,])![
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], lb[22], lb[23], lb[24], lb[25], lb[26],
+			lb[27], lb[28]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset30(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
 		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,])![
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], lb[22], lb[23], lb[24], lb[25], lb[26],
+			lb[27], lb[28], lb[29]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset31(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
 		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,])![
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], lb[22], lb[23], lb[24], lb[25], lb[26],
+			lb[27], lb[28], lb[29], lb[30]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
 	/// <inheritdoc cref="ArrayMemoryManager{T}.ComputeOffset2(Array)"/>
+#if NET5_0_OR_GREATER
+	[SkipLocalsInit]
+#endif
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static IntPtr ComputeOffset32(Array array)
 	{
 		ref Pinnable<T> pinnableRef = ref Unsafe.As<Array, Pinnable<T>>(ref array);
+		ReadOnlySpan<Int32> lb = ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array);
 		ref readonly T dataRef = ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,])![
-			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+			lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+			lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], lb[22], lb[23], lb[24], lb[25], lb[26],
+			lb[27], lb[28], lb[29], lb[30], lb[31]];
 		return Unsafe.ByteOffset(ref pinnableRef.Data, ref Unsafe.AsRef(in dataRef));
 	}
-#endif
 }
 #endif

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedValueHandle.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FixedValueHandle.cs
@@ -57,7 +57,7 @@ internal class FixedValueHandle : IDisposable, IWrapper<Boolean>
 	/// </returns>
 	protected virtual Boolean Dispose(Boolean disposing)
 	{
-		if (this._isDisposed.GetValueOrDefault()) return false;
+		if (!this._isDisposed.HasValue || this._isDisposed.Value) return false;
 		this._isDisposed = true;
 		return true;
 	}

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FrameworkCompat/ArrayCompat.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FrameworkCompat/ArrayCompat.cs
@@ -34,4 +34,19 @@ internal static class ArrayCompat
 		public static readonly T[] EmptyArray = [];
 	}
 #endif
+	/// <summary>
+	/// Retrieves a read-only span of lower bounds for each array dimension.
+	/// </summary>
+	/// <param name="lowerBounds">Destination lower bound span.</param>
+	/// <param name="array">Current array instance.</param>
+	/// <returns>A read-only view of <paramref name="lowerBounds"/>.</returns>
+#if !PACKAGE
+	[ExcludeFromCodeCoverage]
+#endif
+	public static ReadOnlySpan<Int32> GetLowerBounds(Span<Int32> lowerBounds, Array array)
+	{
+		for (Int32 i = 0; i < array.Length; i++)
+			lowerBounds[i] = array.GetLowerBound(i);
+		return lowerBounds;
+	}
 }

--- a/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FrameworkCompat/ArrayCompat.cs
+++ b/src/Intermediate/Rxmxnx.PInvoke.Common.Intermediate/Internal/FrameworkCompat/ArrayCompat.cs
@@ -45,7 +45,7 @@ internal static class ArrayCompat
 #endif
 	public static ReadOnlySpan<Int32> GetLowerBounds(Span<Int32> lowerBounds, Array array)
 	{
-		for (Int32 i = 0; i < array.Length; i++)
+		for (Int32 i = 0; i < array.Rank; i++)
 			lowerBounds[i] = array.GetLowerBound(i);
 		return lowerBounds;
 	}

--- a/src/PackageReference.props
+++ b/src/PackageReference.props
@@ -4,6 +4,7 @@
         <DefineConstants Condition="'$(PackageVersion)' != '9999.99.99.99-tmp'">$(DefineConstants);RELEASE_PACKAGE</DefineConstants>
         <PInvokeVersion Condition="'$(IsLegacyProject)' != 'true'">netstandard2.1</PInvokeVersion>
         <PInvokeVersion Condition="'$(IsLegacyProject)' == 'true'">netstandard2.0</PInvokeVersion>
+        <Version Condition="'$(UsePackage)' == 'true'">$(PackageVersion)</Version>
     </PropertyGroup>
     <ItemGroup Condition="'$(UsePackage)' != 'true'">
         <ProjectReference Include="$(MSBuildThisFileDirectory)Intermediate\Rxmxnx.PInvoke.Common.Intermediate\Rxmxnx.PInvoke.Common.Intermediate.csproj"/>

--- a/src/Test/DotnetCoreAppTests.props
+++ b/src/Test/DotnetCoreAppTests.props
@@ -1,95 +1,53 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <!-- LIMITED_LEGACY_SUPPORT -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
+    <PropertyGroup>
+        <TestSdkVersion>17.3.3</TestSdkVersion>
+        <VisualStudioRunnerVersion Condition="'$(TargetFramework)' == 'netcoreapp2.0'">2.4.1</VisualStudioRunnerVersion>
+        <VisualStudioRunnerVersion Condition="'$(TargetFramework)' != 'netcoreapp2.0'">2.4.3</VisualStudioRunnerVersion>
+        <CoverletColectorVersion Condition="'$(TargetFramework)' == 'net452'">6.0.0</CoverletColectorVersion>
+        <CoverletColectorVersion Condition="'$(TargetFramework)' != 'net452'">6.0.4</CoverletColectorVersion>
+        <TaskExtensionsVersion Condition="'$(TargetFramework)' == 'net461'">4.5.4</TaskExtensionsVersion>
+        <TaskExtensionsVersion Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net462'))">4.6.3</TaskExtensionsVersion>
+    </PropertyGroup>
     <!-- LEGACY_SUPPORT -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
+    <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">
+        <TestSdkVersion>17.13.0</TestSdkVersion>
+        <VisualStudioRunnerVersion>2.4.5</VisualStudioRunnerVersion>
+    </PropertyGroup>
     <!-- OLD_SUPPORTED -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <!-- CURRENT_SUPPORTED -->
-    <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="10.0.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
+        <TestSdkVersion>17.13.0</TestSdkVersion>
+        <VisualStudioRunnerVersion>3.0.2</VisualStudioRunnerVersion>
+    </PropertyGroup>
     <!-- NETFRAMEWORK_SUPPORT -->
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3"/>
-        <PackageReference Condition="!$([MSBuild]::IsOSPlatform('WINDOWS'))" Include="Microsoft.TestPlatform.ObjectModel" Version="17.3.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Condition="'$(TargetFramework)' == 'net452'" Include="coverlet.collector" Version="6.0.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-        <PackageReference Condition="'$(TargetFramework)' != 'net452'" Include="coverlet.collector" Version="6.0.4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And '$(TargetFramework)' != 'net452' And '$(TargetFramework)' != 'net46'">
-        <PackageReference Condition="'$(TargetFramework)' == 'net461'" Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-        <PackageReference Condition="'$(TargetFramework)' != 'net461'" Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
-    </ItemGroup>
-    <!-- NETCOREAPP2.X_SUPPORT -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1'">
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3"/>
+    <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::IsOSPlatform('WINDOWS'))">
+        <TestSdkVersion Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net462'))">18.9.0</TestSdkVersion>
+        <VisualStudioRunnerVersion Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net462'))">2.4.5</VisualStudioRunnerVersion>
+        <VisualStudioRunnerVersion Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net472'))">4.0.0</VisualStudioRunnerVersion>
+    </PropertyGroup>
+    <!-- CURRENT_SUPPORTED -->
+    <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+        <TestSdkVersion>18.9.0</TestSdkVersion>
+        <VisualStudioRunnerVersion>4.0.0</VisualStudioRunnerVersion>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETStandard'">
         <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.0'" Include="Microsoft.NETCore.App" Version="2.0.9"/>
         <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.1'" Include="Microsoft.NETCore.App" Version="2.1.30"/>
-        <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.1'" Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="$(VisualStudioRunnerVersion)">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.0'" Include="xunit.runner.visualstudio" Version="2.4.1">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="$(CoverletColectorVersion)">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+        <PackageReference Condition="'$(TaskExtensionsVersion)' != ''" Include="System.Threading.Tasks.Extensions" Version="$(TaskExtensionsVersion)"/>
+        <PackageReference Condition="!$([MSBuild]::IsOSPlatform('WINDOWS'))" Include="Microsoft.TestPlatform.ObjectModel" Version="$(TestSdkVersion)"/>
     </ItemGroup>
 
 </Project>

--- a/src/Test/DotnetCoreAppTests.props
+++ b/src/Test/DotnetCoreAppTests.props
@@ -42,7 +42,7 @@
     <!-- CURRENT_SUPPORTED -->
     <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Test/DotnetCoreAppTests.props
+++ b/src/Test/DotnetCoreAppTests.props
@@ -6,7 +6,7 @@
         <VisualStudioRunnerVersion Condition="'$(TargetFramework)' == 'netcoreapp2.0'">2.4.1</VisualStudioRunnerVersion>
         <VisualStudioRunnerVersion Condition="'$(TargetFramework)' != 'netcoreapp2.0'">2.4.3</VisualStudioRunnerVersion>
         <CoverletColectorVersion Condition="'$(TargetFramework)' == 'net452'">6.0.0</CoverletColectorVersion>
-        <CoverletColectorVersion Condition="'$(TargetFramework)' != 'net452'">6.0.4</CoverletColectorVersion> 
+        <CoverletColectorVersion Condition="'$(TargetFramework)' != 'net452'">6.0.4</CoverletColectorVersion>
         <TaskExtensionsVersion Condition="'$(TargetFramework)' == 'net461'">4.5.4</TaskExtensionsVersion>
         <TaskExtensionsVersion Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net462'))">4.6.3</TaskExtensionsVersion>
     </PropertyGroup>

--- a/src/Test/DotnetCoreAppTests.props
+++ b/src/Test/DotnetCoreAppTests.props
@@ -30,6 +30,7 @@
     <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
         <TestSdkVersion>18.9.0</TestSdkVersion>
         <VisualStudioRunnerVersion>4.0.0</VisualStudioRunnerVersion>
+        <CoverletColectorVersion>10.0.1</CoverletColectorVersion>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETStandard'">

--- a/src/Test/DotnetCoreAppTests.props
+++ b/src/Test/DotnetCoreAppTests.props
@@ -41,7 +41,7 @@
 
     <!-- CURRENT_SUPPORTED -->
     <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/src/Test/DotnetCoreAppTests.props
+++ b/src/Test/DotnetCoreAppTests.props
@@ -6,7 +6,7 @@
         <VisualStudioRunnerVersion Condition="'$(TargetFramework)' == 'netcoreapp2.0'">2.4.1</VisualStudioRunnerVersion>
         <VisualStudioRunnerVersion Condition="'$(TargetFramework)' != 'netcoreapp2.0'">2.4.3</VisualStudioRunnerVersion>
         <CoverletColectorVersion Condition="'$(TargetFramework)' == 'net452'">6.0.0</CoverletColectorVersion>
-        <CoverletColectorVersion Condition="'$(TargetFramework)' != 'net452'">6.0.4</CoverletColectorVersion>
+        <CoverletColectorVersion Condition="'$(TargetFramework)' != 'net452'">6.0.4</CoverletColectorVersion> 
         <TaskExtensionsVersion Condition="'$(TargetFramework)' == 'net461'">4.5.4</TaskExtensionsVersion>
         <TaskExtensionsVersion Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net462'))">4.6.3</TaskExtensionsVersion>
     </PropertyGroup>

--- a/src/Test/Rxmxnx.Assert.Tests/Rxmxnx.Assert.Tests.csproj
+++ b/src/Test/Rxmxnx.Assert.Tests/Rxmxnx.Assert.Tests.csproj
@@ -27,7 +27,7 @@
     <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Condition="'$(TargetFramework)' == 'net452'" Include="Xunit.SkippableFact" Version="1.4.13"/>
-        <PackageReference Condition="'$(TargetFramework)' != 'net452'" Include="Xunit.SkippableFact" Version="1.5.61"/>
+        <PackageReference Condition="'$(TargetFramework)' != 'net452'" Include="Xunit.SkippableFact" Version="1.5.85"/>
         <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.1'" Include="Microsoft.NETCore.App" Version="2.1.30"/>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Test/Rxmxnx.PInvoke.CString.Tests.SourceGenerator/Rxmxnx.PInvoke.CString.Tests.SourceGenerator.csproj
+++ b/src/Test/Rxmxnx.PInvoke.CString.Tests.SourceGenerator/Rxmxnx.PInvoke.CString.Tests.SourceGenerator.csproj
@@ -19,8 +19,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0">
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Test/Rxmxnx.PInvoke.Common.Tests/Internal/FixedValueHandleTests.cs
+++ b/src/Test/Rxmxnx.PInvoke.Common.Tests/Internal/FixedValueHandleTests.cs
@@ -7,17 +7,18 @@ public class FixedValueHandleTests
 	[Fact]
 	public void Test()
 	{
-		IWrapper<Boolean> result = PInvokeAssert.IsType<IWrapper<Boolean>>(FixedValueHandle.EmptyDisposable);
-		PInvokeAssert.False(result.Value);
+		IWrapper<Boolean>? result = FixedValueHandle.EmptyDisposable as IWrapper<Boolean>;
+		PInvokeAssert.NotNull(result!);
+		PInvokeAssert.True(result.Value);
 		FixedValueHandle.EmptyDisposable.Dispose();
-		PInvokeAssert.False(result.Value);
+		PInvokeAssert.True(result.Value);
 		FixedValueHandle.EmptyDisposable.Dispose();
-		PInvokeAssert.False(result.Value);
+		PInvokeAssert.True(result.Value);
 		FixedValueHandle.EmptyDisposable.Dispose();
-		PInvokeAssert.False(result.Value);
+		PInvokeAssert.True(result.Value);
 		FixedValueHandle.EmptyDisposable.Dispose();
-		PInvokeAssert.False(result.Value);
+		PInvokeAssert.True(result.Value);
 		FixedValueHandle.EmptyDisposable.Dispose();
-		PInvokeAssert.False(result.Value);
+		PInvokeAssert.True(result.Value);
 	}
 }

--- a/src/Test/Rxmxnx.PInvoke.Common.Tests/Internal/FixedValueHandleTests.cs
+++ b/src/Test/Rxmxnx.PInvoke.Common.Tests/Internal/FixedValueHandleTests.cs
@@ -1,0 +1,23 @@
+namespace Rxmxnx.PInvoke.Tests.Internal;
+
+[TestFixture]
+[ExcludeFromCodeCoverage]
+public class FixedValueHandleTests
+{
+	[Fact]
+	public void Test()
+	{
+		IWrapper<Boolean> result = PInvokeAssert.IsType<IWrapper<Boolean>>(FixedValueHandle.EmptyDisposable);
+		PInvokeAssert.False(result.Value);
+		FixedValueHandle.EmptyDisposable.Dispose();
+		PInvokeAssert.False(result.Value);
+		FixedValueHandle.EmptyDisposable.Dispose();
+		PInvokeAssert.False(result.Value);
+		FixedValueHandle.EmptyDisposable.Dispose();
+		PInvokeAssert.False(result.Value);
+		FixedValueHandle.EmptyDisposable.Dispose();
+		PInvokeAssert.False(result.Value);
+		FixedValueHandle.EmptyDisposable.Dispose();
+		PInvokeAssert.False(result.Value);
+	}
+}

--- a/src/Test/Rxmxnx.PInvoke.Extensions.Tests/ArrayReferenceHelper.cs
+++ b/src/Test/Rxmxnx.PInvoke.Extensions.Tests/ArrayReferenceHelper.cs
@@ -7,67 +7,120 @@ internal static class ArrayReferenceHelper
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static ref T GetArrayDataReference<T>(Array? array)
 	{
+		ReadOnlySpan<Int32> lb = array is not null ?
+			ArrayCompat.GetLowerBounds(stackalloc Int32[array.Rank], array) :
+			ReadOnlySpan<Int32>.Empty;
+		// ReSharper disable once ConvertSwitchStatementToSwitchExpression
 		switch (array?.Rank)
 		{
-			case 1: return ref new Span<T>(array as T[])[0];
-			case 2: return ref (array as T[,])![0, 0];
-			case 3: return ref (array as T[,,])![0, 0, 0];
-			case 4: return ref (array as T[,,,])![0, 0, 0, 0];
-			case 5: return ref (array as T[,,,,])![0, 0, 0, 0, 0];
-			case 6: return ref (array as T[,,,,,])![0, 0, 0, 0, 0, 0];
-			case 7: return ref (array as T[,,,,,,])![0, 0, 0, 0, 0, 0, 0];
-			case 8: return ref (array as T[,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0];
-			case 9: return ref (array as T[,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0];
-			case 10: return ref (array as T[,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-			case 11: return ref (array as T[,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-			case 12: return ref (array as T[,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-			case 13: return ref (array as T[,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-			case 14: return ref (array as T[,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-			case 15: return ref (array as T[,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-			case 16: return ref (array as T[,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-			case 17: return ref (array as T[,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-			case 18: return ref (array as T[,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+			case 1: return ref new Span<T>(array as T[])[lb[0]];
+			case 2: return ref (array as T[,])![lb[0], lb[1]];
+			case 3: return ref (array as T[,,])![lb[0], lb[1], lb[2]];
+			case 4: return ref (array as T[,,,])![lb[0], lb[1], lb[2], lb[3]];
+			case 5: return ref (array as T[,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4]];
+			case 6: return ref (array as T[,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5]];
+			case 7: return ref (array as T[,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6]];
+			case 8: return ref (array as T[,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7]];
+			case 9: return ref (array as T[,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8]];
+			case 10:
+				return ref (array as T[,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8],
+				                                    lb[9]];
+			case 11:
+				return ref (array as T[,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8],
+				                                     lb[9], lb[10]];
+			case 12:
+				return ref (array as T[,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8],
+				                                      lb[9], lb[10], lb[11]];
+			case 13:
+				return ref (array as T[,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8],
+				                                       lb[9], lb[10], lb[11], lb[12]];
+			case 14:
+				return ref (array as T[,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8],
+				                                        lb[9], lb[10], lb[11], lb[12], lb[13]];
+			case 15:
+				return ref (array as T[,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8],
+				                                         lb[9], lb[10], lb[11], lb[12], lb[13], lb[14]];
+			case 16:
+				return ref (array as T[,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8],
+				                                          lb[9], lb[10], lb[11], lb[12], lb[13], lb[14], lb[15]];
+			case 17:
+				return ref (array as T[,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7],
+				                                           lb[8], lb[9], lb[10], lb[11], lb[12], lb[13], lb[14], lb[15],
+				                                           lb[16]];
+			case 18:
+				return ref (array as T[,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7],
+				                                            lb[8], lb[9], lb[10], lb[11], lb[12], lb[13], lb[14],
+				                                            lb[15], lb[16], lb[17]];
 			case 19:
-				return ref (array as T[,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+				return ref (array as T[,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7],
+				                                             lb[8], lb[9], lb[10], lb[11], lb[12], lb[13], lb[14],
+				                                             lb[15], lb[16], lb[17], lb[18]];
 			case 20:
-				return ref (array as T[,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				                                              0];
+				return ref (array as T[,,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7],
+				                                              lb[8], lb[9], lb[10], lb[11], lb[12], lb[13], lb[14],
+				                                              lb[15], lb[16], lb[17], lb[18], lb[19]];
 			case 21:
-				return ref (array as T[,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				                                               0, 0];
+				return ref (array as T[,,,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7],
+				                                               lb[8], lb[9], lb[10], lb[11], lb[12], lb[13], lb[14],
+				                                               lb[15], lb[16], lb[17], lb[18], lb[19], lb[20]];
 			case 22:
-				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				                                                0, 0, 0];
+				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7],
+				                                                lb[8], lb[9], lb[10], lb[11], lb[12], lb[13], lb[14],
+				                                                lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21]];
 			case 23:
-				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				                                                 0, 0, 0, 0, 0];
+				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7],
+				                                                 lb[8], lb[9], lb[10], lb[11], lb[12], lb[13], lb[14],
+				                                                 lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21],
+				                                                 lb[22]];
 			case 24:
-				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				                                                  0, 0, 0, 0, 0, 0];
+				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+				                                                  lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+				                                                  lb[14], lb[15], lb[16], lb[17], lb[18], lb[19],
+				                                                  lb[20], lb[21], lb[22], lb[23]];
 			case 25:
-				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				                                                   0, 0, 0, 0, 0, 0, 0];
+				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+				                                                   lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+				                                                   lb[14], lb[15], lb[16], lb[17], lb[18], lb[19],
+				                                                   lb[20], lb[21], lb[22], lb[23], lb[24]];
 			case 26:
-				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				                                                    0, 0, 0, 0, 0, 0, 0, 0, 0];
+				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+				                                                    lb[7], lb[8], lb[9], lb[10], lb[11], lb[12], lb[13],
+				                                                    lb[14], lb[15], lb[16], lb[17], lb[18], lb[19],
+				                                                    lb[20], lb[21], lb[22], lb[23], lb[24], lb[25]];
 			case 27:
-				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				                                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+				                                                     lb[7], lb[8], lb[9], lb[10], lb[11], lb[12],
+				                                                     lb[13], lb[14], lb[15], lb[16], lb[17], lb[18],
+				                                                     lb[19], lb[20], lb[21], lb[22], lb[23], lb[24],
+				                                                     lb[25], lb[26]];
 			case 28:
-				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				                                                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+				                                                      lb[7], lb[8], lb[9], lb[10], lb[11], lb[12],
+				                                                      lb[13], lb[14], lb[15], lb[16], lb[17], lb[18],
+				                                                      lb[19], lb[20], lb[21], lb[22], lb[23], lb[24],
+				                                                      lb[25], lb[26], lb[27]];
 			case 29:
-				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				                                                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+				                                                       lb[7], lb[8], lb[9], lb[10], lb[11], lb[12],
+				                                                       lb[13], lb[14], lb[15], lb[16], lb[17], lb[18],
+				                                                       lb[19], lb[20], lb[21], lb[22], lb[23], lb[24],
+				                                                       lb[25], lb[26], lb[27], lb[28]];
 			case 30:
-				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,])![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				                                                        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,])![lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6],
+				                                                        lb[7], lb[8], lb[9], lb[10], lb[11], lb[12],
+				                                                        lb[13], lb[14], lb[15], lb[16], lb[17], lb[18],
+				                                                        lb[19], lb[20], lb[21], lb[22], lb[23], lb[24],
+				                                                        lb[25], lb[26], lb[27], lb[28], lb[29]];
 			case 31:
 				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,])![
-					0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+					lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12],
+					lb[13], lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], lb[22], lb[23], lb[24],
+					lb[25], lb[26], lb[27], lb[28], lb[29], lb[30]];
 			case 32:
 				return ref (array as T[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,])![
-					0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+					lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7], lb[8], lb[9], lb[10], lb[11], lb[12],
+					lb[13], lb[14], lb[15], lb[16], lb[17], lb[18], lb[19], lb[20], lb[21], lb[22], lb[23], lb[24],
+					lb[25], lb[26], lb[27], lb[28], lb[29], lb[30], lb[31]];
 			default:
 				return ref Unsafe.NullRef<T>();
 		}

--- a/src/Test/Tests.props
+++ b/src/Test/Tests.props
@@ -22,6 +22,8 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
         <DefineConstants Condition="'$(MultipleFrameworkTest)' == 'true'">$(DefineConstants);MULTIPLE_FRAMEWORK</DefineConstants>
         <NoWarn Condition="'$(TargetFramework)' == 'netstandard2.1'">$(NoWarn);MSB3243</NoWarn>
         <NoWarn Condition="'$(TargetFramework)' == 'netcoreapp2.0'">$(NoWarn);NU1902;NU1903;NETSDK1023</NoWarn>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes to low-level array pinning offsets and dispose semantics can affect P/Invoke memory safety across TFMs; most other edits are CI, packaging, and dependency updates.
> 
> **Overview**
> Fixes **`FixedValueHandle.Dispose`** so handles with a **null** `_isDisposed` (notably `EmptyDisposable`) are not flipped to “disposed” on the first `Dispose()` call; adds tests that repeated disposes on the empty handle keep **`Value`** true.
> 
> **`ArrayMemoryManager`** offset calculation and the pre-.NET 6 test **`ArrayReferenceHelper`** now index multi-dimensional arrays at each dimension’s **lower bound** via new **`ArrayCompat.GetLowerBounds`**, instead of assuming index zero everywhere. Higher-rank offset helpers are enabled for UAP where they were previously gated, with **`SkipLocalsInit`** on .NET 5+.
> 
> **UWP / CI packaging:** the Windows application test project patches **`Package.appxmanifest`** identity version from **`PackageVersion`** at build time; launcher **`CompileAppxArgs`** supplies a timestamp-based **`AppxPackageVersion`**. Manifest min OS is raised to **10.0.16299**. **`PackageReference.props`** sets **`Version`** when **`UsePackage`** is true.
> 
> **Build/test maintenance:** CI runs **`dotnet clean`** before Sonar; **`Microsoft.Build.Utilities.Core`** and several test/analyzer packages are bumped; **`DotnetCoreAppTests.props`** centralizes test SDK/runner/coverlet versions (including **18.9.x** on current TFMs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9616aeaf643f2c0a3847dd86cc6564ffdda60240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->